### PR TITLE
Convert specifications to Markdown

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -1,5 +1,14 @@
 # DECISION Log
 
+## 2025-05-15 14:30 - Specification Conversion Strategy
+- **Problem**: Convert downloaded specifications (HTML and PDF) to Markdown for readability and AI consumption, as required by GEMINI.md.
+- **Solution 1**: Use `lynx -dump` for HTML and `strings` for PDF.
+  - Reasoning: Uses pre-installed tools but results in poor formatting and potential data loss for PDFs.
+- **Solution 2 (Chosen)**: Use `html2text` for HTML and `pdfminer.six` (`pdf2txt.py`) for PDF.
+  - Reasoning: These specialized libraries provide much better Markdown/text conversion quality, preserving structure and links better than generic tools.
+- **Solution 3**: Manual conversion/transcription.
+  - Reasoning: Extremely time-consuming and prone to human error, although high quality.
+
 ## 2024-03-14 10:45 - Fifth Framework Choice
 - **Problem**: GEMINI.md requires adding one more framework of choice to the fusion list.
 - **Solution 1 (Chosen)**: PRINCE2. It is a widely recognized, process-based method for effective project management that complements the existing list well, especially Hermes and RUP.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,6 @@
 # ROADMAP
 
 ## Planned
-- [ ] Convert original specifications to Markdown
 - [ ] Research AI-friendly schema formats (JSON-LD, etc.) for the unified system.
 - [ ] Define initial set of unified roles based on the five frameworks.
 - [ ] Define unified deliverables and process steps.
@@ -10,5 +9,6 @@
 ## Proposed
 
 ## Finished
+- [x] 2025-05-15: Convert original specifications to Markdown.
 - [x] 2024-03-14: Download framework specifications (RUP, V-Modell-XT, Hermes, SCRUM, PRINCE2) to `/specifications`.
 - [x] 2024-03-14: Bootstrap project structure and initial documentation.

--- a/specifications/Hermes/hermes.md
+++ b/specifications/Hermes/hermes.md
@@ -1,0 +1,116 @@
+**Hermes** (Eigenschreibweise: **HERMES**) ist ein [offener Standard](/wiki/Offener_Standard "Offener Standard") zur Führung und Abwicklung von [IT](/wiki/Informationstechnik "Informationstechnik")-Projekten. Der Name steht als [Akronym](/wiki/Akronym "Akronym") für „**H** andbuch der **E** lektronischen **R** echenzentren des Bundes, eine **M** ethode zur **E** ntwicklung von **S** ystemen“.
+
+## Geschichte
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=1 "Abschnitt bearbeiten: Geschichte") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=1 "Quellcode des Abschnitts bearbeiten: Geschichte")]
+
+Als [Projektführungsinstrument](/wiki/Projektplanung "Projektplanung") ist es seit 1975 in der Bundesverwaltung der [Schweiz](/wiki/Schweiz "Schweiz") im Einsatz. Nach einer grösseren Überarbeitung im Jahr 1986 wurde Hermes für alle IT-Projekte des Bundes verbindlich[1]. 2006 wird Hermes als Standard beim Verein _eCH_ anerkannt, welcher [E-Government](/wiki/E-Government "E-Government")-Standards fördert, entwickelt und verabschiedet[2]. Heute (Stand: 2016) arbeiten auch viele kantonale Ämter und grössere Städte mit Hermes.
+
+Am 26. April 2006 wurde das Projekt _Quapital_ (_QUAlité des Projets d'Implémentation des Technologies de l'information et de la communication dans l'Administration Luxembourgeoise_) der Regierung von [Luxemburg](/wiki/Luxemburg "Luxemburg") vorgestellt. Das Ziel vom Teilbereich _Quapital_ Werkzeuge ist es konsistente Daten auf allen Ebenen (Projekt, Programm und Portfolio) zu erhalten. Dieses Tool basiert vollständig auf Quapital-Hermes.[3]
+
+Hermes wird durch das [Informatiksteuerungsorgan des Bundes](/wiki/Informatiksteuerungsorgan_des_Bundes "Informatiksteuerungsorgan des Bundes") betreut.
+
+  * April 2013: Hermes 5[4]
+  * Juni 2014: Hermes 5.1
+  * Oktober 2020: Hermes 2021
+
+In Version 5.1 wurde die Methodik um die Möglichkeit zur [Agilen Entwicklung](/wiki/Agile_Softwareentwicklung "Agile Softwareentwicklung") z. B. mit [Scrum](/wiki/Scrum "Scrum") ergänzt. Ab 2015 sind alle Bundesstellen verpflichtet, die Methode Hermes für ihre Projekte (auch Nicht-IT-Projekte) zu adaptieren und einzusetzen. Die Hermes Methodik, Entwicklung und der Betrieb erfolgt nach einer WTO-Ausschreibung von 2019 durch _Stoupa & Partners AG_ (Methodik) und I _CTpark_ (Entwicklung und Betrieb)[2].
+
+## Szenarien
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=2 "Abschnitt bearbeiten: Szenarien") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=2 "Quellcode des Abschnitts bearbeiten: Szenarien")]
+
+### Hermes 5.1
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=3 "Abschnitt bearbeiten: Hermes 5.1") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=3 "Quellcode des Abschnitts bearbeiten: Hermes 5.1")]
+
+Projekte, in denen Hermes eingesetzt wird, können sich bezüglich ihres Inhalts und der Komplexität unterscheiden. Hermes bietet aus diesem Grund unterschiedliche Szenarien an. Ein Szenario ist auf die Durchführung von Projekten mit der spezifischen Charakteristik ausgerichtet. Das Szenario umfasst den gesamten Lebenszyklus vom Projekt ab und beinhaltet die Methodenelemente die für das Projekt von Bedeutung sind[5].
+
+Szenarien bestehen aus Modulen, die thematisch zusammengehörende Aufgaben und Ergebnisse gruppieren. Hermes bietet folgende acht Standardszenarien an[5]:
+
+  * Dienstleistung/Produkt
+  * IT-Individualanwendung
+  * IT-Standardanwendung
+  * IT-Anwendung Weiterentwicklung
+  * IT-Infrastruktur
+  * Organisationsanpassung
+  * Dienstleistung/Produkt agil
+  * IT-Individualanwendung agil
+
+### Hermes Ausgabe 2022
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=4 "Abschnitt bearbeiten: Hermes Ausgabe 2022") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=4 "Quellcode des Abschnitts bearbeiten: Hermes Ausgabe 2022")]
+
+Hermes Ausgabe 2022 bietet fünf Standardszenarien für Projekte mit verschiedenen Charakteristiken an:[6]
+
+  * Dienstleistung/Produkt Entwicklung
+  * Dienstleistung/Produkt Adaption
+  * IT-Entwicklung
+  * IT-Adaption
+  * Organisationsanpassung
+
+### Individuelle Szenarien
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=5 "Abschnitt bearbeiten: Individuelle Szenarien") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=5 "Quellcode des Abschnitts bearbeiten: Individuelle Szenarien")]
+
+Szenarien können angepasst oder individuell erstellt werden. Dazu gibt es vier grundlegende Möglichkeiten[5]:
+
+  1. Module aus einem bestehenden Szenario entfernen.
+  2. Aufgaben und Ergebnisse aus einem bestehenden Szenario entfernen.
+  3. Ein zusätzliches Modul in ein Szenario integrieren.
+  4. Aufgaben und Ergebnisse in ein Szenario integrieren.
+
+## Ausbildung und Zertifizierung
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=6 "Abschnitt bearbeiten: Ausbildung und Zertifizierung") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=6 "Quellcode des Abschnitts bearbeiten: Ausbildung und Zertifizierung")]
+
+Schulungen können bei verschiedenen Seminaranbietern besucht werden. Für Hermes gibt es zwei Zertifizierungen für Personen.
+
+### Foundation Level
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=7 "Abschnitt bearbeiten: Foundation Level") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=7 "Quellcode des Abschnitts bearbeiten: Foundation Level")]
+
+Das Foundation Level (deutsch: Grundlagen Level) ist ein Grundlagen Wissenstest zur [Projektmanagement](/wiki/Projektmanagement "Projektmanagement")-Methodologie Hermes. Die Prüfung dauert eine Stunde und besteht aus 40 Multiple-Choice-Fragen. Die Themenbereiche umfassen die Hermes Grundlagen, Anwendungsbereich und Aufbau des Standardszenarios, Module des Standardszenarios und Projektorganisation (Rollen) des Standardszenarios. Als Zielgruppe für die Zertifizierung werden Projektmitarbeitende, Juniorprojektleiter, Entscheidungsträger, Auftraggeber und Projektcontroller genannt.[7]
+
+### Advanced Level
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=8 "Abschnitt bearbeiten: Advanced Level") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=8 "Quellcode des Abschnitts bearbeiten: Advanced Level")]
+
+Das Advanced Level (deutsch: Fortgeschrittenes Level) ist ein Fortgeschrittener Wissenstest zur Projektmanagement-Methodologie Hermes. Die Prüfung besteht aus zwei Teilen. Beide Teile dauern je 60 Minuten (gültig für Prüfungen nach Lernzielen/Referenzhandbuch/Format 2019). Der erste Teil besteht aus 30 [Multiple-Choice](/wiki/Multiple_Choice "Multiple Choice")-Fragen und der zweite aus 15 Multiple-Choice-Fragen mit Praxissituation. Die Themenbereiche umfassen die Hermes Grundlagen, Module IT-System, IT-Betrieb und IT-Migration der Standardszenarien, Module Projektgrundlagen und Projektführung des Standardszenarios und das Modul Projektsteuerung. Als Zielgruppe für die Zertifizierung werden Projektleiter, Projektmanager und Teilprojektleiter genannt.[8]
+
+### Advanced Level (Recertification)
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=9 "Abschnitt bearbeiten: Advanced Level \(Recertification\)") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=9 "Quellcode des Abschnitts bearbeiten: Advanced Level \(Recertification\)")]
+
+Die Rezertifizierung erfolgt auf Antrag des Teilnehmers vor Ablauf des Zertifizierungszeitraums in der Regel frühestens ein Jahr vor Ablauf des Zertifikats.[9]
+
+Um eine Rezertifizierung durchzuführen, sind folgende Anforderungen durch die Teilnehmer zu erfüllen:
+
+  1. Nachweis einer Veranstaltungsteilnahme zum Thema Projektmanagement und / oder Hermes und
+  2. Nachweis von Weiterbildungseinheiten zum Thema Projektmanagement und / oder Hermes (mindestens 8 Unterrichtseinheiten von je 45 Minuten) und
+  3. Berufserfahrung: Eine Rolle der Führung, Steuerung, Ausführung oder Wissensvermittlung gemäß Hermes innerhalb der Zertifizierungsphase (eine Beschreibung mit Bestätigung des Arbeit-/ Auftraggebers).
+
+## Weblinks
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=10 "Abschnitt bearbeiten: Weblinks") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=10 "Quellcode des Abschnitts bearbeiten: Weblinks")]
+
+  * [Ausbildung und Zertifizierung](https://www.isb.admin.ch/isb/de/home/themen/projektmanagement/hermes/ausbildung_zertifizierung.html)
+  * [HERMES – Die schweizerische Projektführungsmethode](https://www.hermes.admin.ch/)
+
+## Einzelnachweise
+
+[[Bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&veaction=edit&section=11 "Abschnitt bearbeiten: Einzelnachweise") | [Quelltext bearbeiten](/w/index.php?title=Hermes_\(Projektmanagementmethode\)&action=edit&section=11 "Quellcode des Abschnitts bearbeiten: Einzelnachweise")]
+
+  1. ↑ [_Bericht der Geschäftsprüfungskommission des Ständerates vom 19. November 1998,_Einrichtung von Online-Verbindungen im Bereich des Polizeiwesens_._](https://www.parlament.ch/centers/documents/de/ed-pa-aufsichtskommission-frueher-3-d.pdf) parlament.ch, abgerufen am 23. August 2015.
+  2. ↑ a b _Die Geschichte der Projektführungsmethode HERMES._ Informatiksteuerungsorgan des Bundes ISB, 8. Januar 2020, ehemals im [Original](https://redirecter.toolforge.org/?url=https%3A%2F%2Fwww.isb.admin.ch%2Fdam%2Fisb%2Fde%2Fdokumente%2Fthemen%2Fhermes%2FDie_Geschichte_HERMES_2020.pdf.download.pdf%2FDie_Geschichte_HERMES_2020.pdf) (nicht mehr online verfügbar); abgerufen am 11. August 2020.[@1](http://deadurl.invalid/https://www.isb.admin.ch/dam/isb/de/dokumente/themen/hermes/Die_Geschichte_HERMES_2020.pdf.download.pdf/Die_Geschichte_HERMES_2020.pdf)[@2](https://www.isb.admin.ch/dam/isb/de/dokumente/themen/hermes/Die_Geschichte_HERMES_2020.pdf.download.pdf/Die_Geschichte_HERMES_2020.pdf)[Vorlage:Toter Link/www.isb.admin.ch](/w/index.php?title=Vorlage:Toter_Link/www.isb.admin.ch&action=edit&redlink=1 "Vorlage:Toter Link/www.isb.admin.ch \(Seite nicht vorhanden\)") ([Seite nicht mehr abrufbar](/wiki/Wikipedia:Defekte_Weblinks "Wikipedia:Defekte Weblinks"). [Suche in Webarchiven](http://timetravel.mementoweb.org/list/2010/https://www.isb.admin.ch/dam/isb/de/dokumente/themen/hermes/Die_Geschichte_HERMES_2020.pdf.download.pdf/Die_Geschichte_HERMES_2020.pdf))
+  3. ↑ [_Claude Wiseler présente le programme Quapital (Qualité des projets d'implémentation des technologies de l'information et de la communication dans l'administration luxembourgeoise)._](https://gouvernement.lu/fr/actualites/toutes_actualites/articles/2006/04/26wiseler_quapital.html) 25\. April 2006, abgerufen am 30. April 2020 (französisch).
+  4. ↑ [_Trailer zur Version 5._](https://www.youtube.com/watch?feature=player_embedded&v=o3Pz5O_mzmA) Abgerufen am 7. Mai 2014.
+  5. ↑ a b c [_Szenarien._](https://www.hermes.admin.ch/de/projektmanagement/verstehen/szenarien.html) Abgerufen am 22. Juli 2020.
+  6. ↑ Hermes Referenzhandbuch – Projektmanagement, Ausgabe 2022
+  7. ↑ [_Hermes Foundation._](https://www.tuev-sued.ch/ch-de/ueber-tuev-sued/tuev-sued-in-der-schweiz/examination-institute/hermes-5-deutsche-version/hermes-5-foundation) Abgerufen am 6. Januar 2020.
+  8. ↑ [_Hermes Advanced._](https://www.tuev-sued.ch/ch-de/ueber-tuev-sued/tuev-sued-in-der-schweiz/examination-institute/hermes-5-deutsche-version/hermes-5-advanced) Abgerufen am 6. Januar 2020.
+  9. ↑ [_Hermes Advanced Recertification._](https://www.tuev-sued.ch/ch-de/ueber-tuev-sued/tuev-sued-in-der-schweiz/examination-institute/hermes-5-deutsche-version/hermes-5-advanced-recertification) Abgerufen am 6. Januar 2020.
+
+![](https://de.wikipedia.org/wiki/Special:CentralAutoLogin/start?useformat=desktop&type=1x1&usesul3=1)
+
+Abgerufen von „[https://de.wikipedia.org/w/index.php?title=Hermes_(Projektmanagementmethode)&oldid=257327612](https://de.wikipedia.org/w/index.php?title=Hermes_\(Projektmanagementmethode\)&oldid=257327612)“

--- a/specifications/Hermes/hermes.original.html
+++ b/specifications/Hermes/hermes.original.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 skin-theme-clientpref-day vector-sticky-header-enabled vector-toc-not-available skin-theme-clientpref-thumb-standard" lang="de" dir="ltr">
+<html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 skin-theme-clientpref-day vector-sticky-header-enabled vector-toc-available skin-theme-clientpref-thumb-standard" lang="de" dir="ltr">
 <head>
 <meta charset="UTF-8">
-<title>Hermes (Projektsteuerungsmethode) – Wikipedia</title>
-<script>(function(){var className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 skin-theme-clientpref-day vector-sticky-header-enabled vector-toc-not-available skin-theme-clientpref-thumb-standard";var cookie=document.cookie.match(/(?:^|; )dewikimwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\w+$|[^\w-]+/g,'')+'-clientpref-\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":[",\t.",".\t,"],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","Januar","Februar","März","April","Mai","Juni","Juli","August","September","Oktober","November","Dezember"],"wgRequestId":"4f5b940c-fb24-43bc-9f9a-daf8f9c4ba74","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Hermes_(Projektsteuerungsmethode)","wgTitle":"Hermes (Projektsteuerungsmethode)","wgCurRevisionId":0,"wgRevisionId":0,"wgArticleId":0,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":[],"wgPageViewLanguage":"de","wgPageContentLanguage":"de","wgPageContentModel":"wikitext","wgRelevantPageName":"Hermes_(Projektsteuerungsmethode)","wgRelevantArticleId":0,"wgTempUserName":null,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionCreate":[],"wgNoticeProject":"wikipedia","wgCiteReferencePreviewsActive":true,"wgFlaggedRevsParams":{"tags":{"accuracy":{"levels":1}}},"wgStableRevisionId":0,"wgConfirmEditCaptchaNeededForGenericEdit":false,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgPopupsFlags":0,"wgVisualEditor":{"pageLanguageCode":"de","pageLanguageDir":"ltr","pageVariantFallbacks":"de"},"wgMFDisplayWikibaseDescriptions":{"search":true,"watchlist":true,"tagline":true,"nearby":true},"wgWMESchemaEditAttemptStepOversample":false,"wgWMEPageLength":0,"wgEditSubmitButtonLabelPublish":true,"wgVisualEditorPageIsDisambiguation":false,"wgULSPosition":"interlanguage","wgULSisCompactLinksEnabled":false,"wgVector2022LanguageInHeader":true,"wgULSisLanguageSelectorEmpty":true,"wgCheckUserClientHintsHeadersJsApi":["brands","architecture","bitness","fullVersionList","mobile","model","platform","platformVersion"],"GEHomepageSuggestedEditsEnableTopics":true,"wgGESuggestedEditsTaskTypes":{"taskTypes":["link-recommendation"],"unavailableTaskTypes":[]},"wgGETopicsMatchModeEnabled":false,"wgGELevelingUpEnabledForUser":false,"wgTestKitchenUserExperiments":{"active_experiments":[],"overrides":[],"enrolled":[],"assigned":[],"subject_ids":[],"sampling_units":[],"coordinator":[]}};
-RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ext.gadget.dewikiCommonHide":"ready","ext.gadget.dewikiCommonLayout":"ready","ext.gadget.dewikiCommonStyle":"ready","ext.gadget.dewikiDarkmode":"ready","ext.gadget.dewikiResponsive":"ready","ext.globalCssJs.user.styles":"ready","site.styles":"ready","user.styles":"ready","ext.globalCssJs.user":"ready","user":"ready","user.options":"loading","ext.inputBox.styles":"ready","ext.wikimediamessages.styles":"ready","skins.vector.search.codex.styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","mediawiki.ui.button":"ready","ext.flaggedRevs.basic":"ready","mediawiki.codex.messagebox.styles":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.uls.interlanguage":"ready"};RLPAGEMODULES=["ext.parsermigration.survey","site","mediawiki.page.ready","skins.vector.js","ext.centralNotice.geoIP","ext.centralNotice.startUp","ext.flaggedRevs.advanced","ext.gadget.createNewSection","ext.gadget.navileisteAutocollapse","ext.gadget.WikiMiniAtlas","ext.gadget.OpenStreetMap","ext.gadget.CommonsDirekt","ext.urlShortener.toolbar","ext.centralauth.centralautologin","ext.popups","ext.visualEditor.desktopArticleTarget.init","ext.echo.centralauth","ext.eventLogging","ext.wikimediaEvents","ext.navigationTiming","ext.uls.interface","ext.cx.eventlogging.campaigns","wikibase.databox.fromWikidata","ext.checkUser.clientHints","ext.growthExperiments.SuggestedEditSession","ext.testKitchen"];</script>
+<title>Hermes (Projektmanagementmethode) – Wikipedia</title>
+<script>(function(){var className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 skin-theme-clientpref-day vector-sticky-header-enabled vector-toc-available skin-theme-clientpref-thumb-standard";var cookie=document.cookie.match(/(?:^|; )dewikimwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\w+$|[^\w-]+/g,'')+'-clientpref-\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":[",\t.",".\t,"],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","Januar","Februar","März","April","Mai","Juni","Juli","August","September","Oktober","November","Dezember"],"wgRequestId":"af0758ba-4f4a-415d-98f7-a70e6fe52be1","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Hermes_(Projektmanagementmethode)","wgTitle":"Hermes (Projektmanagementmethode)","wgCurRevisionId":257327612,"wgRevisionId":257327612,"wgArticleId":8220636,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Wikipedia:Weblink offline","Projektmanagement"],"wgPageViewLanguage":"de","wgPageContentLanguage":"de","wgPageContentModel":"wikitext","wgRelevantPageName":"Hermes_(Projektmanagementmethode)","wgRelevantArticleId":8220636,"wgTempUserName":null,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgNoticeProject":"wikipedia","wgCiteReferencePreviewsActive":true,"wgFlaggedRevsParams":{"tags":{"accuracy":{"levels":1}}},"wgStableRevisionId":257327612,"wgConfirmEditCaptchaNeededForGenericEdit":false,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgPopupsFlags":0,"wgVisualEditor":{"pageLanguageCode":"de","pageLanguageDir":"ltr","pageVariantFallbacks":"de"},"wgMFDisplayWikibaseDescriptions":{"search":true,"watchlist":true,"tagline":true,"nearby":true},"wgWMESchemaEditAttemptStepOversample":false,"wgWMEPageLength":8000,"wgEditSubmitButtonLabelPublish":true,"wgVisualEditorPageIsDisambiguation":false,"wgULSPosition":"interlanguage","wgULSisCompactLinksEnabled":false,"wgVector2022LanguageInHeader":true,"wgULSisLanguageSelectorEmpty":false,"wgWikibaseItemId":"Q1431655","wgCheckUserClientHintsHeadersJsApi":["brands","architecture","bitness","fullVersionList","mobile","model","platform","platformVersion"],"GEHomepageSuggestedEditsEnableTopics":true,"wgGESuggestedEditsTaskTypes":{"taskTypes":["link-recommendation"],"unavailableTaskTypes":[]},"wgGETopicsMatchModeEnabled":false,"wgGELevelingUpEnabledForUser":false,"wgTestKitchenUserExperiments":{"active_experiments":[],"overrides":[],"enrolled":[],"assigned":[],"subject_ids":[],"sampling_units":[],"coordinator":[]}};
+RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ext.gadget.dewikiCommonHide":"ready","ext.gadget.dewikiCommonLayout":"ready","ext.gadget.dewikiCommonStyle":"ready","ext.gadget.dewikiDarkmode":"ready","ext.gadget.dewikiResponsive":"ready","ext.globalCssJs.user.styles":"ready","site.styles":"ready","user.styles":"ready","ext.globalCssJs.user":"ready","user":"ready","user.options":"loading","ext.wikimediamessages.styles":"ready","ext.cite.styles":"ready","skins.vector.search.codex.styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","ext.flaggedRevs.basic":"ready","mediawiki.codex.messagebox.styles":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.uls.interlanguage":"ready","wikibase.client.init":"ready"};RLPAGEMODULES=["ext.parsermigration.survey","ext.cite.ux-enhancements","site","mediawiki.page.ready","mediawiki.toc","skins.vector.js","ext.centralNotice.geoIP","ext.centralNotice.startUp","ext.flaggedRevs.advanced","ext.gadget.createNewSection","ext.gadget.navileisteAutocollapse","ext.gadget.WikiMiniAtlas","ext.gadget.OpenStreetMap","ext.gadget.CommonsDirekt","ext.urlShortener.toolbar","ext.centralauth.centralautologin","ext.popups","ext.visualEditor.desktopArticleTarget.init","ext.echo.centralauth","ext.eventLogging","ext.wikimediaEvents","ext.navigationTiming","ext.uls.interface","ext.cx.eventlogging.campaigns","ext.cx.uls.quick.actions","wikibase.client.vector-2022","wikibase.databox.fromWikidata","ext.checkUser.clientHints","ext.quicksurveys.init","ext.growthExperiments.SuggestedEditSession","ext.testKitchen"];</script>
 <script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
 }];});});</script>
-<link rel="stylesheet" href="/w/load.php?lang=de&amp;modules=ext.flaggedRevs.basic%7Cext.inputBox.styles%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediamessages.styles%7Cmediawiki.codex.messagebox.styles%7Cmediawiki.ui.button%7Cskins.vector.icons%2Cstyles%7Cskins.vector.search.codex.styles&amp;only=styles&amp;skin=vector-2022">
+<link rel="stylesheet" href="/w/load.php?lang=de&amp;modules=ext.cite.styles%7Cext.flaggedRevs.basic%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediamessages.styles%7Cmediawiki.codex.messagebox.styles%7Cskins.vector.icons%2Cstyles%7Cskins.vector.search.codex.styles%7Cwikibase.client.init&amp;only=styles&amp;skin=vector-2022">
 <script async="" src="/w/load.php?lang=de&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector-2022"></script>
 <meta name="ResourceLoaderDynamicStyles" content="">
 <link rel="stylesheet" href="/w/load.php?lang=de&amp;modules=ext.gadget.citeRef%2CdefaultPlainlinks%2CdewikiCommonHide%2CdewikiCommonLayout%2CdewikiCommonStyle%2CdewikiDarkmode%2CdewikiResponsive&amp;only=styles&amp;skin=vector-2022">
@@ -15,23 +15,23 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 <meta name="generator" content="MediaWiki 1.46.0-wmf.19">
 <meta name="referrer" content="origin">
 <meta name="referrer" content="origin-when-cross-origin">
-<meta name="robots" content="noindex,nofollow,max-image-preview:standard">
+<meta name="robots" content="max-image-preview:standard">
 <meta name="format-detection" content="telephone=no">
 <meta name="viewport" content="width=1120">
-<meta property="og:title" content="Hermes (Projektsteuerungsmethode) – Wikipedia">
+<meta property="og:title" content="Hermes (Projektmanagementmethode) – Wikipedia">
 <meta property="og:type" content="website">
-<link rel="alternate" type="application/x-wiki" title="Seite bearbeiten" href="/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;action=edit">
+<link rel="alternate" type="application/x-wiki" title="Seite bearbeiten" href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit">
 <link rel="apple-touch-icon" href="/static/apple-touch/wikipedia.png">
 <link rel="icon" href="/static/favicon/wikipedia.ico">
 <link rel="search" type="application/opensearchdescription+xml" href="/w/rest.php/v1/search" title="Wikipedia (de)">
 <link rel="EditURI" type="application/rsd+xml" href="//de.wikipedia.org/w/api.php?action=rsd">
-<link rel="canonical" href="https://de.wikipedia.org/wiki/Hermes_(Projektsteuerungsmethode)">
+<link rel="canonical" href="https://de.wikipedia.org/wiki/Hermes_(Projektmanagementmethode)">
 <link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">
 <link rel="alternate" type="application/atom+xml" title="Atom-Feed für „Wikipedia“" href="/w/index.php?title=Spezial:Letzte_%C3%84nderungen&amp;feed=atom">
 <link rel="dns-prefetch" href="//meta.wikimedia.org" />
 <link rel="dns-prefetch" href="auth.wikimedia.org">
 </head>
-<body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Hermes_Projektsteuerungsmethode rootpage-Hermes_Projektsteuerungsmethode skin-vector-2022 action-view">
+<body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Hermes_Projektmanagementmethode rootpage-Hermes_Projektmanagementmethode skin-vector-2022 action-view">
 <div id="mw-aria-live-region" class="mw-aria-live-region" aria-live="polite"></div><a class="mw-jump-link" href="#bodyContent">Zum Inhalt springen</a>
 <div class="vector-header-container">
 	<header class="vector-header mw-header no-font-mode-scale">
@@ -200,9 +200,9 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 		<ul class="vector-menu-content-list">
 			<li id="pt-sitesupport-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw-interface  href="https://donate.wikimedia.org/?wmf_source=donate&amp;wmf_medium=sidebar&amp;wmf_campaign=de.wikipedia.org&amp;uselang=de" class=""><span>Jetzt spenden</span></a>
 </li>
-<li id="pt-createaccount-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw-interface  href="/w/index.php?title=Spezial:Benutzerkonto_anlegen&amp;returnto=Hermes+%28Projektsteuerungsmethode%29" title="Wir ermutigen dich dazu, ein Benutzerkonto zu erstellen und dich anzumelden. Es ist jedoch nicht zwingend erforderlich." class=""><span>Benutzerkonto erstellen</span></a>
+<li id="pt-createaccount-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw-interface  href="/w/index.php?title=Spezial:Benutzerkonto_anlegen&amp;returnto=Hermes+%28Projektmanagementmethode%29" title="Wir ermutigen dich dazu, ein Benutzerkonto zu erstellen und dich anzumelden. Es ist jedoch nicht zwingend erforderlich." class=""><span>Benutzerkonto erstellen</span></a>
 </li>
-<li id="pt-login-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw-interface  href="/w/index.php?title=Spezial:Anmelden&amp;returnto=Hermes+%28Projektsteuerungsmethode%29" title="Anmelden ist zwar keine Pflicht, wird aber gerne gesehen. [o]" accesskey="o" class=""><span>Anmelden</span></a>
+<li id="pt-login-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw-interface  href="/w/index.php?title=Spezial:Anmelden&amp;returnto=Hermes+%28Projektmanagementmethode%29" title="Anmelden ist zwar keine Pflicht, wird aber gerne gesehen. [o]" accesskey="o" class=""><span>Anmelden</span></a>
 </li>
 
 
@@ -228,7 +228,7 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 		<ul class="vector-menu-content-list">
 
-			<li id="pt-sitesupport" class="user-links-collapsible-item mw-list-item"><a href="https://donate.wikimedia.org/?wmf_source=donate&amp;wmf_medium=sidebar&amp;wmf_campaign=de.wikipedia.org&amp;uselang=de"><span>Jetzt spenden</span></a></li><li id="pt-createaccount" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Spezial:Benutzerkonto_anlegen&amp;returnto=Hermes+%28Projektsteuerungsmethode%29" title="Wir ermutigen dich dazu, ein Benutzerkonto zu erstellen und dich anzumelden. Es ist jedoch nicht zwingend erforderlich."><span class="vector-icon mw-ui-icon-userAdd mw-ui-icon-wikimedia-userAdd"></span> <span>Benutzerkonto erstellen</span></a></li><li id="pt-login" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Spezial:Anmelden&amp;returnto=Hermes+%28Projektsteuerungsmethode%29" title="Anmelden ist zwar keine Pflicht, wird aber gerne gesehen. [o]" accesskey="o"><span class="vector-icon mw-ui-icon-logIn mw-ui-icon-wikimedia-logIn"></span> <span>Anmelden</span></a></li>
+			<li id="pt-sitesupport" class="user-links-collapsible-item mw-list-item"><a href="https://donate.wikimedia.org/?wmf_source=donate&amp;wmf_medium=sidebar&amp;wmf_campaign=de.wikipedia.org&amp;uselang=de"><span>Jetzt spenden</span></a></li><li id="pt-createaccount" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Spezial:Benutzerkonto_anlegen&amp;returnto=Hermes+%28Projektmanagementmethode%29" title="Wir ermutigen dich dazu, ein Benutzerkonto zu erstellen und dich anzumelden. Es ist jedoch nicht zwingend erforderlich."><span class="vector-icon mw-ui-icon-userAdd mw-ui-icon-wikimedia-userAdd"></span> <span>Benutzerkonto erstellen</span></a></li><li id="pt-login" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Spezial:Anmelden&amp;returnto=Hermes+%28Projektmanagementmethode%29" title="Anmelden ist zwar keine Pflicht, wird aber gerne gesehen. [o]" accesskey="o"><span class="vector-icon mw-ui-icon-logIn mw-ui-icon-wikimedia-logIn"></span> <span>Anmelden</span></a></li>
 		</ul>
 
 	</div>
@@ -258,23 +258,218 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 		</nav>
 		</div>
 	</div>
+	<div class="vector-sticky-pinned-container">
+				<nav id="mw-panel-toc" aria-label="Inhaltsverzeichnis" data-event-name="ui.sidebar-toc" class="mw-table-of-contents-container vector-toc-landmark">
+					<div id="vector-toc-pinned-container" class="vector-pinned-container">
+					<div id="vector-toc" class="vector-toc vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-toc-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="toc-pinned"
+	data-pinnable-element-id="vector-toc"
+	data-pinned-container-id="vector-toc-pinned-container"
+	data-unpinned-container-id="vector-toc-unpinned-container"
+>
+	<h2 class="vector-pinnable-header-label">Inhaltsverzeichnis</h2>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-toc.pin">In die Seitenleiste verschieben</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-toc.unpin">Verbergen</button>
 </div>
+
+
+	<ul class="vector-toc-contents" id="mw-panel-toc-list">
+		<li id="toc-mw-content-text"
+			class="vector-toc-list-item vector-toc-level-1">
+			<a href="#" class="vector-toc-link">
+				<div class="vector-toc-text">(Anfang)</div>
+			</a>
+		</li>
+		<li id="toc-Geschichte"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Geschichte">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">1</span>
+				<span>Geschichte</span>
+			</div>
+		</a>
+
+		<ul id="toc-Geschichte-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-Szenarien"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Szenarien">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">2</span>
+				<span>Szenarien</span>
+			</div>
+		</a>
+
+			<button aria-controls="toc-Szenarien-sublist" class="cdx-button cdx-button--weight-quiet cdx-button--icon-only vector-toc-toggle">
+				<span class="vector-icon mw-ui-icon-wikimedia-expand"></span>
+				<span>Unterabschnitt Szenarien umschalten</span>
+			</button>
+
+		<ul id="toc-Szenarien-sublist" class="vector-toc-list">
+			<li id="toc-Hermes_5.1"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Hermes_5.1">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">2.1</span>
+					<span>Hermes 5.1</span>
+				</div>
+			</a>
+
+			<ul id="toc-Hermes_5.1-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Hermes_Ausgabe_2022"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Hermes_Ausgabe_2022">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">2.2</span>
+					<span>Hermes Ausgabe 2022</span>
+				</div>
+			</a>
+
+			<ul id="toc-Hermes_Ausgabe_2022-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Individuelle_Szenarien"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Individuelle_Szenarien">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">2.3</span>
+					<span>Individuelle Szenarien</span>
+				</div>
+			</a>
+
+			<ul id="toc-Individuelle_Szenarien-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+	</ul>
+	</li>
+	<li id="toc-Ausbildung_und_Zertifizierung"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Ausbildung_und_Zertifizierung">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">3</span>
+				<span>Ausbildung und Zertifizierung</span>
+			</div>
+		</a>
+
+			<button aria-controls="toc-Ausbildung_und_Zertifizierung-sublist" class="cdx-button cdx-button--weight-quiet cdx-button--icon-only vector-toc-toggle">
+				<span class="vector-icon mw-ui-icon-wikimedia-expand"></span>
+				<span>Unterabschnitt Ausbildung und Zertifizierung umschalten</span>
+			</button>
+
+		<ul id="toc-Ausbildung_und_Zertifizierung-sublist" class="vector-toc-list">
+			<li id="toc-Foundation_Level"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Foundation_Level">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">3.1</span>
+					<span>Foundation Level</span>
+				</div>
+			</a>
+
+			<ul id="toc-Foundation_Level-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Advanced_Level"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Advanced_Level">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">3.2</span>
+					<span>Advanced Level</span>
+				</div>
+			</a>
+
+			<ul id="toc-Advanced_Level-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Advanced_Level_(Recertification)"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Advanced_Level_(Recertification)">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">3.3</span>
+					<span>Advanced Level (Recertification)</span>
+				</div>
+			</a>
+
+			<ul id="toc-Advanced_Level_(Recertification)-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+	</ul>
+	</li>
+	<li id="toc-Weblinks"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Weblinks">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">4</span>
+				<span>Weblinks</span>
+			</div>
+		</a>
+
+		<ul id="toc-Weblinks-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-Einzelnachweise"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Einzelnachweise">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">5</span>
+				<span>Einzelnachweise</span>
+			</div>
+		</a>
+
+		<ul id="toc-Einzelnachweise-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+</ul>
+</div>
+
+					</div>
+		</nav>
+			</div>
+		</div>
 		<div class="mw-content-container">
 			<main id="content" class="mw-body">
 				<header class="mw-body-header vector-page-titlebar no-font-mode-scale">
-					<h1 id="firstHeading" class="firstHeading mw-first-heading"><span lang="de" dir="ltr"><span class="mw-page-title-main">Hermes (Projektsteuerungsmethode)</span></span></h1>
+					<nav aria-label="Inhaltsverzeichnis" class="vector-toc-landmark">
 
-<div id="p-lang-btn" class="vector-dropdown mw-portlet mw-portlet-lang mw-portlet-lang-icon-only"  >
-	<input type="checkbox" id="p-lang-btn-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-p-lang-btn" class="vector-dropdown-checkbox mw-interlanguage-selector-empty" aria-label="Dieser Artikel ist nur in dieser Sprache vorhanden. Füge den Artikel für andere Sprachen hinzu"   >
-	<label id="p-lang-btn-label" for="p-lang-btn-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only mw-portlet-lang-heading-empty" aria-hidden="true"  ><span class="vector-icon mw-ui-icon-language mw-ui-icon-wikimedia-language"></span>
+<div id="vector-page-titlebar-toc" class="vector-dropdown vector-page-titlebar-toc vector-button-flush-left"  title="Inhaltsverzeichnis" >
+	<input type="checkbox" id="vector-page-titlebar-toc-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-titlebar-toc" class="vector-dropdown-checkbox "  aria-label="Inhaltsverzeichnis umschalten"  >
+	<label id="vector-page-titlebar-toc-label" for="vector-page-titlebar-toc-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-listBullet mw-ui-icon-wikimedia-listBullet"></span>
 
-<span class="vector-dropdown-label-text">Sprachen hinzufügen</span>
+<span class="vector-dropdown-label-text">Inhaltsverzeichnis umschalten</span>
 	</label>
 	<div class="vector-dropdown-content">
 
-		<div class="mw-portlet-empty-language-selector-body">
-						Seiteninhalte werden in anderen Sprachen nicht unterstützt.
-					</div>
+
+							<div id="vector-page-titlebar-toc-unpinned-container" class="vector-unpinned-container">
+			</div>
+
+	</div>
+</div>
+
+					</nav>
+					<h1 id="firstHeading" class="firstHeading mw-first-heading"><span class="mw-page-title-main">Hermes (Projektmanagementmethode)</span></h1>
+
+<div id="p-lang-btn" class="vector-dropdown mw-portlet mw-portlet-lang"  >
+	<input type="checkbox" id="p-lang-btn-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-p-lang-btn" class="vector-dropdown-checkbox mw-interlanguage-selector" aria-label="Zu einem Artikel in einer anderen Sprache gehen. Verfügbar in 5 Sprachen"   >
+	<label id="p-lang-btn-label" for="p-lang-btn-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--action-progressive mw-portlet-lang-heading-5" aria-hidden="true"  ><span class="vector-icon mw-ui-icon-language-progressive mw-ui-icon-wikimedia-language-progressive"></span>
+
+<span class="vector-dropdown-label-text">5 Sprachen</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+		<div class="vector-menu-content">
+
+			<ul class="vector-menu-content-list">
+
+				<li class="interlanguage-link interwiki-bg mw-list-item"><a href="https://bg.wikipedia.org/wiki/%D0%A5%D0%B5%D1%80%D0%BC%D0%B5%D1%81_%D0%9C%D0%B5%D1%82%D0%BE%D0%B4" title="Хермес Метод – Bulgarisch" lang="bg" hreflang="bg" data-title="Хермес Метод" data-language-autonym="Български" data-language-local-name="Bulgarisch" class="interlanguage-link-target"><span>Български</span></a></li><li class="interlanguage-link interwiki-en mw-list-item"><a href="https://en.wikipedia.org/wiki/HERMES_method" title="HERMES method – Englisch" lang="en" hreflang="en" data-title="HERMES method" data-language-autonym="English" data-language-local-name="Englisch" class="interlanguage-link-target"><span>English</span></a></li><li class="interlanguage-link interwiki-es mw-list-item"><a href="https://es.wikipedia.org/wiki/M%C3%A9todo_Hermes" title="Método Hermes – Spanisch" lang="es" hreflang="es" data-title="Método Hermes" data-language-autonym="Español" data-language-local-name="Spanisch" class="interlanguage-link-target"><span>Español</span></a></li><li class="interlanguage-link interwiki-fi mw-list-item"><a href="https://fi.wikipedia.org/wiki/HERMES" title="HERMES – Finnisch" lang="fi" hreflang="fi" data-title="HERMES" data-language-autonym="Suomi" data-language-local-name="Finnisch" class="interlanguage-link-target"><span>Suomi</span></a></li><li class="interlanguage-link interwiki-fr mw-list-item"><a href="https://fr.wikipedia.org/wiki/HERMES_(m%C3%A9thode)" title="HERMES (méthode) – Französisch" lang="fr" hreflang="fr" data-title="HERMES (méthode)" data-language-autonym="Français" data-language-local-name="Französisch" class="interlanguage-link-target"><span>Français</span></a></li>
+			</ul>
+			<div class="after-portlet after-portlet-lang"><span class="wb-langlinks-edit wb-langlinks-link"><a href="https://www.wikidata.org/wiki/Special:EntityPage/Q1431655#sitelinks-wikipedia" title="Links auf Artikel in anderen Sprachen bearbeiten" class="wbc-editpage">Links bearbeiten</a></span></div>
+		</div>
 
 	</div>
 </div>
@@ -289,7 +484,7 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 		<ul class="vector-menu-content-list">
 
-			<li id="ca-nstab-main" class="selected vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;action=edit&amp;redlink=1" title="Seiteninhalt anzeigen (Seite nicht vorhanden) [c]" accesskey="c"><span>Artikel</span></a></li><li id="ca-talk" class="new vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Diskussion:Hermes_(Projektsteuerungsmethode)&amp;action=edit&amp;redlink=1" rel="discussion" class="new" title="Diskussion zum Seiteninhalt (Seite nicht vorhanden) [t]" accesskey="t"><span>Diskussion</span></a></li>
+			<li id="ca-nstab-main" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Hermes_(Projektmanagementmethode)" title="Seiteninhalt anzeigen [c]" accesskey="c"><span>Artikel</span></a></li><li id="ca-talk" class="vector-tab-noicon mw-list-item"><a href="/wiki/Diskussion:Hermes_(Projektmanagementmethode)" rel="discussion" title="Diskussion zum Seiteninhalt [t]" accesskey="t"><span>Diskussion</span></a></li>
 		</ul>
 
 	</div>
@@ -329,7 +524,7 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 		<ul class="vector-menu-content-list">
 
-			<li id="ca-ve-edit" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;veaction=edit" title="Diese Seite erstellen [v]" accesskey="v"><span>Erstellen</span></a></li><li id="ca-edit" class="collapsible vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;action=edit" title="Den Quelltext dieser Seite erstellen [e]" accesskey="e"><span>Quelltext erstellen</span></a></li>
+			<li id="ca-view" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Hermes_(Projektmanagementmethode)"><span>Lesen</span></a></li><li id="ca-ve-edit" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit" title="Diese Seite mit dem VisualEditor bearbeiten [v]" accesskey="v"><span>Bearbeiten</span></a></li><li id="ca-edit" class="collapsible vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit" title="Den Quelltext dieser Seite bearbeiten [e]" accesskey="e"><span>Quelltext bearbeiten</span></a></li><li id="ca-history" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=history" title="Frühere Versionen dieser Seite listen [h]" accesskey="h"><span>Versionsgeschichte</span></a></li>
 		</ul>
 
 	</div>
@@ -370,7 +565,7 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 		<ul class="vector-menu-content-list">
 
-			<li id="ca-more-ve-edit" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;veaction=edit" title="Diese Seite erstellen [v]" accesskey="v"><span>Erstellen</span></a></li><li id="ca-more-edit" class="collapsible vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;action=edit" title="Den Quelltext dieser Seite erstellen [e]" accesskey="e"><span>Quelltext erstellen</span></a></li>
+			<li id="ca-more-view" class="selected vector-more-collapsible-item mw-list-item"><a href="/wiki/Hermes_(Projektmanagementmethode)"><span>Lesen</span></a></li><li id="ca-more-ve-edit" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit" title="Diese Seite mit dem VisualEditor bearbeiten [v]" accesskey="v"><span>Bearbeiten</span></a></li><li id="ca-more-edit" class="collapsible vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit" title="Den Quelltext dieser Seite bearbeiten [e]" accesskey="e"><span>Quelltext bearbeiten</span></a></li><li id="ca-more-history" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=history"><span>Versionsgeschichte</span></a></li>
 		</ul>
 
 	</div>
@@ -384,13 +579,27 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 		<ul class="vector-menu-content-list">
 
-			<li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Spezial:Linkliste/Hermes_(Projektsteuerungsmethode)" title="Liste aller Seiten, die hierher verlinken [j]" accesskey="j"><span>Links auf diese Seite</span></a></li><li id="t-print" class="mw-list-item"><a href="javascript:print();" rel="alternate" title="Druckansicht dieser Seite [p]" accesskey="p"><span>Druckversion</span></a></li><li id="t-info" class="mw-list-item"><a href="/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;action=info" title="Weitere Informationen über diese Seite"><span>Seiten­­informationen</span></a></li><li id="t-urlshortener" class="mw-list-item"><a href="/w/index.php?title=Spezial:URL-K%C3%BCrzung&amp;url=https%3A%2F%2Fde.wikipedia.org%2Fwiki%2FHermes_%28Projektsteuerungsmethode%29"><span>Kurzlink</span></a></li>
+			<li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Spezial:Linkliste/Hermes_(Projektmanagementmethode)" title="Liste aller Seiten, die hierher verlinken [j]" accesskey="j"><span>Links auf diese Seite</span></a></li><li id="t-recentchangeslinked" class="mw-list-item"><a href="/wiki/Spezial:%C3%84nderungen_an_verlinkten_Seiten/Hermes_(Projektmanagementmethode)" rel="nofollow" title="Letzte Änderungen an Seiten, die von hier verlinkt sind [k]" accesskey="k"><span>Änderungen an verlinkten Seiten</span></a></li><li id="t-permalink" class="mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;oldid=257327612" title="Dauerhafter Link zu dieser Seitenversion"><span>Permanenter Link</span></a></li><li id="t-info" class="mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=info" title="Weitere Informationen über diese Seite"><span>Seiten­­informationen</span></a></li><li id="t-cite" class="mw-list-item"><a href="/w/index.php?title=Spezial:Zitierhilfe&amp;page=Hermes_%28Projektmanagementmethode%29&amp;id=257327612&amp;wpFormIdentifier=titleform" title="Hinweise, wie diese Seite zitiert werden kann"><span>Artikel zitieren</span></a></li><li id="t-urlshortener" class="mw-list-item"><a href="/w/index.php?title=Spezial:URL-K%C3%BCrzung&amp;url=https%3A%2F%2Fde.wikipedia.org%2Fwiki%2FHermes_%28Projektmanagementmethode%29"><span>Kurzlink</span></a></li>
 		</ul>
 
 	</div>
 </div>
 
-<div id="p-wikibase-otherprojects" class="vector-menu mw-portlet mw-portlet-wikibase-otherprojects emptyPortlet"  >
+<div id="p-coll-print_export" class="vector-menu mw-portlet mw-portlet-coll-print_export"  >
+	<div class="vector-menu-heading">
+		Drucken/​exportieren
+	</div>
+	<div class="vector-menu-content">
+
+		<ul class="vector-menu-content-list">
+
+			<li id="coll-download-as-rl" class="mw-list-item"><a href="/w/index.php?title=Spezial:DownloadAsPdf&amp;page=Hermes_%28Projektmanagementmethode%29&amp;action=show-download-screen"><span>Als PDF herunterladen</span></a></li><li id="t-print" class="mw-list-item"><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;printable=yes" title="Druckansicht dieser Seite [p]" accesskey="p"><span>Druckversion</span></a></li>
+		</ul>
+
+	</div>
+</div>
+
+<div id="p-wikibase-otherprojects" class="vector-menu mw-portlet mw-portlet-wikibase-otherprojects"  >
 	<div class="vector-menu-heading">
 		In anderen Projekten
 	</div>
@@ -398,7 +607,7 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 		<ul class="vector-menu-content-list">
 
-
+			<li id="t-wikibase" class="wb-otherproject-link wb-otherproject-wikibase-dataitem mw-list-item"><a href="https://www.wikidata.org/wiki/Special:EntityPage/Q1431655" title="Link zum verbundenen Objekt im Datenrepositorium [g]" accesskey="g"><span>Wikidata-Datenobjekt</span></a></li>
 		</ul>
 
 	</div>
@@ -455,35 +664,125 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 					<div id="contentSub"><div id="mw-content-subtitle"></div></div>
 
 
-					<div id="mw-content-text" class="mw-body-content"><div class="noarticletext mw-content-ltr" dir="ltr" lang="de">
-<div style="overflow: auto;">
-<div class="noarticletext"><div style="font-size:larger" role="alert"><b>Dieser Artikel existiert nicht.</b></div>
-<div class="mw-parser-output" style="margin-top:1em; margin-bottom:1em; max-width:50em;" role="navigation">
-<style data-mw-deduplicate="TemplateStyles:r261937569">body.skin-minerva .mw-parser-output .mw-ui-button{min-width:1.25em;padding:0.75em;font-size:initial;line-height:0}.mw-parser-output .cdx-button,.mw-parser-output .mw-ui-button{background-color:#f8f9fa;color:#222222;display:inline-block;box-sizing:border-box;min-width:4em;max-width:28.75em;margin:0;padding:0.546875em 1em;border-color:#a2a9b1;border-style:solid;border-width:1px;border-radius:2px;font-family:inherit;font-size:1em;font-weight:bold;line-height:1.286;text-align:center;vertical-align:middle;cursor:pointer}.mw-parser-output .cdx-button:visited,.mw-parser-output .mw-ui-button:visited{color:#222222}.mw-parser-output .cdx-button:hover,.mw-parser-output .mw-ui-button:hover{background-color:#ffffff;color:#444444;border-color:#a2a9b1}.mw-parser-output .cdx-button:focus,.mw-parser-output .mw-ui-button:focus{background-color:#ffffff;color:#222222;border-color:#3366cc;box-shadow:inset 0 0 0 1px #3366cc,inset 0 0 0 2px #ffffff;outline-width:0}.mw-parser-output .cdx-button:active,.mw-parser-output .mw-ui-button:active,.mw-parser-output .cdx-button.is-on,.mw-parser-output .mw-ui-button.is-on{background-color:#c8ccd1;color:#000000;border-color:#72777d;box-shadow:none}.mw-parser-output .cdx-button:disabled,.mw-parser-output .mw-ui-button:disabled,.mw-parser-output .cdx-button.mw-ui-quiet.mw-ui-progressive,.mw-parser-output .mw-ui-button.mw-ui-quiet.mw-ui-progressive,.mw-parser-output .cdx-button.mw-ui-quiet.mw-ui-destructive,.mw-parser-output .mw-ui-button.mw-ui-quiet.mw-ui-destructive{background-color:#c8ccd1;color:#ffffff;border-color:#c8ccd1;cursor:default}.mw-parser-output .cdx-button:disabled:hover,.mw-parser-output .mw-ui-button:disabled:hover,.mw-parser-output .cdx-button.mw-ui-quiet.mw-ui-progressive:hover,.mw-parser-output .mw-ui-button.mw-ui-quiet.mw-ui-progressive:hover,.mw-parser-output .cdx-button.mw-ui-quiet.mw-ui-destructive:hover,.mw-parser-output .mw-ui-button.mw-ui-quiet.mw-ui-destructive:hover,.mw-parser-output .cdx-button:disabled:active,.mw-parser-output .mw-ui-button:disabled:active,.mw-parser-output .cdx-button.mw-ui-quiet.mw-ui-progressive:active,.mw-parser-output .mw-ui-button.mw-ui-quiet.mw-ui-progressive:active,.mw-parser-output .cdx-button.mw-ui-quiet.mw-ui-destructive:active,.mw-parser-output .mw-ui-button.mw-ui-quiet.mw-ui-destructive:active{background-color:#c8ccd1;color:#ffffff;box-shadow:none;border-color:#c8ccd1}.mw-parser-output .cdx-button:not(:disabled),.mw-parser-output .mw-ui-button:not(:disabled){transition:background-color 100ms,color 100ms,border-color 100ms,box-shadow 100ms}.mw-parser-output .cdx-button.mw-ui-quiet,.mw-parser-output .mw-ui-button.mw-ui-quiet{background-color:transparent;color:#222222;border-color:transparent}.mw-parser-output .cdx-button.mw-ui-quiet:hover,.mw-parser-output .mw-ui-button.mw-ui-quiet:hover{background-color:transparent;color:#444444;border-color:transparent;box-shadow:none}.mw-parser-output .cdx-button.mw-ui-quiet:active,.mw-parser-output .mw-ui-button.mw-ui-quiet:active{background-color:transparent;color:#000000;border-color:transparent}.mw-parser-output .cdx-button.mw-ui-quiet:focus,.mw-parser-output .mw-ui-button.mw-ui-quiet:focus{background-color:transparent;color:#222222;border-color:transparent;box-shadow:none}.mw-parser-output .cdx-button.mw-ui-quiet:disabled,.mw-parser-output .mw-ui-button.mw-ui-quiet:disabled{background-color:transparent;color:#c8ccd1;border-color:transparent}.mw-parser-output .cdx-button[type=submit],.mw-parser-output .mw-ui-button[type=submit],.mw-parser-output .cdx-button.mw-ui-progressive,.mw-parser-output .mw-ui-button.mw-ui-progressive{background-color:var(--background-color-progressive,#3366cc);border:1px solid var(--border-color-progressive,#6485d1);color:var(--color-inverted-fixed,#ffffff)}.mw-parser-output .cdx-button[type=submit]:hover,.mw-parser-output .mw-ui-button[type=submit]:hover,.mw-parser-output .cdx-button.mw-ui-progressive:hover,.mw-parser-output .mw-ui-button.mw-ui-progressive:hover{border-color:#447ff5;color:var(--color-inverted-fixed,#ffffff)}.mw-parser-output .cdx-button[type=submit]:focus,.mw-parser-output .mw-ui-button[type=submit]:focus,.mw-parser-output .cdx-button.mw-ui-progressive:focus,.mw-parser-output .mw-ui-button.mw-ui-progressive:focus{box-shadow:inset 0 0 0 1px #3366cc,inset 0 0 0 2px #ffffff}.mw-parser-output .cdx-button[type=submit]:active,.mw-parser-output .mw-ui-button[type=submit]:active,.mw-parser-output .cdx-button.mw-ui-progressive:active,.mw-parser-output .mw-ui-button.mw-ui-progressive:active,.mw-parser-output .cdx-button.mw-ui-progressive.is-on,.mw-parser-output .mw-ui-button.mw-ui-progressive.is-on{background-color:var(--background-color-progressive-subtle,#eaf3ff);border-color:#2a4b8d;box-shadow:none}.mw-parser-output .cdx-button[type=submit]:disabled,.mw-parser-output .mw-ui-button[type=submit]:disabled,.mw-parser-output .cdx-button.mw-ui-progressive:disabled,.mw-parser-output .mw-ui-button.mw-ui-progressive:disabled{background-color:#c8ccd1;color:var(--color-inverted-fixed,#ffffff);border-color:#c8ccd1}.mw-parser-output .cdx-button[type=submit]:disabled:hover,.mw-parser-output .mw-ui-button[type=submit]:disabled:hover,.mw-parser-output .cdx-button[type=submit]:disabled:active,.mw-parser-output .mw-ui-button[type=submit]:disabled:active,.mw-parser-output .cdx-button.mw-ui-progressive:disabled:hover,.mw-parser-output .mw-ui-button.mw-ui-progressive:disabled:hover,.mw-parser-output .cdx-button.mw-ui-progressive:disabled:active,.mw-parser-output .mw-ui-button.mw-ui-progressive:disabled:active{background-color:#c8ccd1;color:var(--color-inverted-fixed,#ffffff);border-color:#c8ccd1;box-shadow:none}.mw-parser-output .cdx-button.mw-ui-progressive.mw-ui-quiet,.mw-parser-output .mw-ui-button.mw-ui-progressive.mw-ui-quiet{color:#3366cc}.mw-parser-output .cdx-button.mw-ui-progressive.mw-ui-quiet:hover,.mw-parser-output .mw-ui-button.mw-ui-progressive.mw-ui-quiet:hover{background-color:transparent;color:#447ff5}.mw-parser-output .cdx-button.mw-ui-progressive.mw-ui-quiet:active,.mw-parser-output .mw-ui-button.mw-ui-progressive.mw-ui-quiet:active{color:#2a4b8d}.mw-parser-output .cdx-button.mw-ui-progressive.mw-ui-quiet:focus,.mw-parser-output .mw-ui-button.mw-ui-progressive.mw-ui-quiet:focus{background-color:transparent;color:#3366cc}.mw-parser-output .cdx-button.mw-ui-destructive,.mw-parser-output .mw-ui-button.mw-ui-destructive{background-color:#dd3333;color:var(--color-inverted-fixed,#ffffff);border:1px solid #dd3333}.mw-parser-output .cdx-button.mw-ui-destructive:hover,.mw-parser-output .mw-ui-button.mw-ui-destructive:hover{background-color:#ff4242;border-color:#ff4242}.mw-parser-output .cdx-button.mw-ui-destructive:focus,.mw-parser-output .mw-ui-button.mw-ui-destructive:focus{box-shadow:inset 0 0 0 1px #dd3333,inset 0 0 0 2px #ffffff}.mw-parser-output .cdx-button.mw-ui-destructive:active,.mw-parser-output .mw-ui-button.mw-ui-destructive:active,.mw-parser-output .cdx-button.mw-ui-destructive.is-on,.mw-parser-output .mw-ui-button.mw-ui-destructive.is-on{background-color:#b32424;border-color:#b32424;box-shadow:none}.mw-parser-output .cdx-button.mw-ui-destructive:disabled,.mw-parser-output .mw-ui-button.mw-ui-destructive:disabled{background-color:#c8ccd1;color:#fff;border-color:#c8ccd1}.mw-parser-output .cdx-button.mw-ui-destructive:disabled:hover,.mw-parser-output .mw-ui-button.mw-ui-destructive:disabled:hover,.mw-parser-output .cdx-button.mw-ui-destructive:disabled:active,.mw-parser-output .mw-ui-button.mw-ui-destructive:disabled:active{background-color:#c8ccd1;color:#fff;border-color:#c8ccd1;box-shadow:none}.mw-parser-output .cdx-button.mw-ui-destructive.mw-ui-quiet,.mw-parser-output .mw-ui-button.mw-ui-destructive.mw-ui-quiet{color:#dd3333}.mw-parser-output .cdx-button.mw-ui-destructive.mw-ui-quiet:hover,.mw-parser-output .mw-ui-button.mw-ui-destructive.mw-ui-quiet:hover{background-color:transparent;color:#ff4242}.mw-parser-output .cdx-button.mw-ui-destructive.mw-ui-quiet:active,.mw-parser-output .mw-ui-button.mw-ui-destructive.mw-ui-quiet:active{color:#b32424}.mw-parser-output .cdx-button.mw-ui-destructive.mw-ui-quiet:focus,.mw-parser-output .mw-ui-button.mw-ui-destructive.mw-ui-quiet:focus{background-color:transparent;color:#dd3333}.mw-parser-output .cdx-button.mw-ui-big,.mw-parser-output .mw-ui-button.mw-ui-big{font-size:1.3em}.mw-parser-output .cdx-button.mw-ui-block,.mw-parser-output .mw-ui-button.mw-ui-block{display:block;width:100%;margin-left:auto;margin-right:auto}.mw-parser-output a.cdx-button,.mw-parser-output a.mw-ui-button{text-decoration:none}.mw-parser-output a.cdx-button:hover,.mw-parser-output a.mw-ui-button:hover,.mw-parser-output a.cdx-button:focus,.mw-parser-output a.mw-ui-button:focus{text-decoration:none}.mw-parser-output .cdx-button-group>*,.mw-parser-output .mw-ui-button-group>*{min-width:48px;border-radius:0;float:left}.mw-parser-output .cdx-button-group>*:first-child,.mw-parser-output .mw-ui-button-group>*:first-child{border-top-left-radius:2px;border-bottom-left-radius:2px}.mw-parser-output .cdx-button-group>*:not(:first-child),.mw-parser-output .mw-ui-button-group>*:not(:first-child){border-left:0}.mw-parser-output .cdx-button-group>*:last-child,.mw-parser-output .mw-ui-button-group>*:last-child{border-top-right-radius:2px;border-bottom-right-radius:2px}.mw-parser-output .cdx-button-group .is-on .button,.mw-parser-output .mw-ui-button-group .is-on .button{cursor:default}.mw-parser-output .cdx-button,.mw-parser-output .mw-ui-button{min-height:1em}.mw-parser-output .cdx-button,.mw-parser-output .mw-ui-button{text-overflow:clip}</style>
-<div class="mw-inputbox-centered" style="background-color: #FFFFFF; color: inherit;"><form name="searchbox" class="searchbox mw-inputbox-form-inline inputbox-searchengine-not-set" action="/wiki/Spezial:Suche"><div class="cdx-text-input"><input class="mw-searchInput searchboxInput cdx-text-input__input" name="search" value="Hermes Projektsteuerungsmethode " placeholder="Schlagwörter" size="70" dir="ltr" aria-label="Nach einem bereits vorhandenen Artikel suchen, ganze Wörter eingeben" /></div> <input type="submit" name="fulltext" value="Artikel suchen" class="cdx-button" /><input type="hidden" value="Search" name="fulltext" /></form></div>
-<div class="newpage-anleitung" style="font-size:90%; line-height:1.1em; margin-top:0.3em;">
-<p>Möglichst ganze Wörter eingeben, die im Artikeltext, insbesondere aber im Lemma vorkommen sollen.
+					<div id="mw-content-text" class="mw-body-content"><div class="mw-subjectpageheader">
+</div><div class="mw-content-ltr mw-parser-output" lang="de" dir="ltr"><p><b>Hermes</b> (Eigenschreibweise: <b>HERMES</b>) ist ein <a href="/wiki/Offener_Standard" title="Offener Standard">offener Standard</a> zur Führung und Abwicklung von <a href="/wiki/Informationstechnik" title="Informationstechnik">IT</a>-Projekten. Der Name steht als <a href="/wiki/Akronym" title="Akronym">Akronym</a> für „<b>H</b>andbuch der <b>E</b>lektronischen <b>R</b>echenzentren des Bundes, eine <b>M</b>ethode zur <b>E</b>ntwicklung von <b>S</b>ystemen“.
 </p>
-<ul><li><a href="/wiki/Hilfe:Suche" title="Hilfe:Suche">Hilfe:Suche</a> – weitere Möglichkeiten zur Suche nach Artikeln</li></ul>
-</div>
-<p><span class="plainlinks"><a class="external text" href="https://www.wikipedia.org/?search=Hermes%20%28Projektsteuerungsmethode%29%20&amp;uselang=de">Suche nach <i>Hermes Projektsteuerungsmethode</i></a> in anderssprachigen Wikipedias</span>
+<meta property="mw:PageProp/toc" />
+<div class="mw-heading mw-heading2"><h2 id="Geschichte">Geschichte</h2><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=1" title="Abschnitt bearbeiten: Geschichte" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=1" title="Quellcode des Abschnitts bearbeiten: Geschichte"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Als <a href="/wiki/Projektplanung" title="Projektplanung">Projektführungsinstrument</a> ist es seit 1975 in der Bundesverwaltung der <a href="/wiki/Schweiz" title="Schweiz">Schweiz</a> im Einsatz. Nach einer grösseren Überarbeitung im Jahr 1986 wurde Hermes für alle IT-Projekte des Bundes verbindlich<sup id="cite&#95;ref-1" class="reference"><a href="#cite_note-1"><span class="cite-bracket">&#91;</span>1<span class="cite-bracket">&#93;</span></a></sup>. 2006 wird Hermes als Standard beim Verein <i>eCH</i> anerkannt, welcher <a href="/wiki/E-Government" title="E-Government">E-Government</a>-Standards fördert, entwickelt und verabschiedet<sup id="cite&#95;ref-:3&#95;2-0" class="reference"><a href="#cite_note-:3-2"><span class="cite-bracket">&#91;</span>2<span class="cite-bracket">&#93;</span></a></sup>. Heute (Stand: 2016) arbeiten auch viele kantonale Ämter und grössere Städte mit Hermes.
+</p><p>Am 26. April 2006 wurde das Projekt <i>Quapital</i> (<i>QUAlité des Projets d'Implémentation des Technologies de l'information et de la communication dans l'Administration Luxembourgeoise</i>) der Regierung von <a href="/wiki/Luxemburg" title="Luxemburg">Luxemburg</a> vorgestellt. Das Ziel vom Teilbereich <i>Quapital</i> Werkzeuge ist es konsistente Daten auf allen Ebenen (Projekt, Programm und Portfolio) zu erhalten. Dieses Tool basiert vollständig auf Quapital-Hermes.<sup id="cite&#95;ref-3" class="reference"><a href="#cite_note-3"><span class="cite-bracket">&#91;</span>3<span class="cite-bracket">&#93;</span></a></sup>
+</p><p>Hermes wird durch das <a href="/wiki/Informatiksteuerungsorgan_des_Bundes" title="Informatiksteuerungsorgan des Bundes">Informatiksteuerungsorgan des Bundes</a> betreut.
 </p>
-</div>
-<hr />
-<div class="plainlinks" style="margin-top:1em;">
-<p><a class="external text" href="https://de.wikipedia.org/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;action=edit"><i>Verfasse einen Artikel zum Thema.</i></a> <span class="newpage-anleitung">(<a href="/wiki/Hilfe:Neuen_Artikel_anlegen" title="Hilfe:Neuen Artikel anlegen">Anleitung</a>).</span>
+<ul><li>April 2013: Hermes 5<sup id="cite&#95;ref-4" class="reference"><a href="#cite_note-4"><span class="cite-bracket">&#91;</span>4<span class="cite-bracket">&#93;</span></a></sup></li>
+<li>Juni 2014: Hermes 5.1</li>
+<li>Oktober 2020: Hermes 2021</li></ul>
+<p>In Version 5.1 wurde die Methodik um die Möglichkeit zur <a href="/wiki/Agile_Softwareentwicklung" title="Agile Softwareentwicklung">Agilen Entwicklung</a> z.&#160;B. mit <a href="/wiki/Scrum" title="Scrum">Scrum</a> ergänzt. Ab 2015 sind alle Bundesstellen verpflichtet, die Methode Hermes für ihre Projekte (auch Nicht-IT-Projekte) zu adaptieren und einzusetzen. Die Hermes Methodik, Entwicklung und der Betrieb erfolgt nach einer WTO-Ausschreibung von 2019 durch <i>Stoupa &amp; Partners AG</i> (Methodik) und I<i>CTpark</i> (Entwicklung und Betrieb)<sup id="cite&#95;ref-:3&#95;2-1" class="reference"><a href="#cite_note-:3-2"><span class="cite-bracket">&#91;</span>2<span class="cite-bracket">&#93;</span></a></sup>.
 </p>
-<div style="font-size:90%; margin-top:1em;">
-<p><b>Artikel verschwunden?</b>
+<div class="mw-heading mw-heading2"><h2 id="Szenarien">Szenarien</h2><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=2" title="Abschnitt bearbeiten: Szenarien" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=2" title="Quellcode des Abschnitts bearbeiten: Szenarien"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<div class="mw-heading mw-heading3"><h3 id="Hermes_5.1">Hermes 5.1</h3><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=3" title="Abschnitt bearbeiten: Hermes 5.1" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=3" title="Quellcode des Abschnitts bearbeiten: Hermes 5.1"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Projekte, in denen Hermes eingesetzt wird, können sich bezüglich ihres Inhalts und der Komplexität unterscheiden. Hermes bietet aus diesem Grund unterschiedliche Szenarien an. Ein Szenario ist auf die Durchführung von Projekten mit der spezifischen Charakteristik ausgerichtet. Das Szenario umfasst den gesamten Lebenszyklus vom Projekt ab und beinhaltet die Methodenelemente die für das Projekt von Bedeutung sind<sup id="cite&#95;ref-:1&#95;5-0" class="reference"><a href="#cite_note-:1-5"><span class="cite-bracket">&#91;</span>5<span class="cite-bracket">&#93;</span></a></sup>.
+</p><p>Szenarien bestehen aus Modulen, die thematisch zusammengehörende Aufgaben und Ergebnisse gruppieren. Hermes bietet folgende acht Standardszenarien an<sup id="cite&#95;ref-:1&#95;5-1" class="reference"><a href="#cite_note-:1-5"><span class="cite-bracket">&#91;</span>5<span class="cite-bracket">&#93;</span></a></sup>:
 </p>
-<ul><li><a class="external text" href="https://de.wikipedia.org/wiki/Hermes_(Projektsteuerungsmethode)">Lade die Seite erneut</a>, falls du sie soeben erstellt hast, da sich die Aktualisierung der Datenbank verzögern kann. Du kannst auch versuchen, den <a class="external text" href="https://de.wikipedia.org/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;action=purge">Servercache zu leeren</a>.</li>
-<li>Falls der Artikel gelöscht wurde, kannst du an den im <a class="external text" href="https://de.wikipedia.org/w/index.php?title=Spezial:Logbuch/delete&amp;page=Hermes_(Projektsteuerungsmethode)">Lösch-Logbuch</a> genannten Administrator Nachfragen richten, so sie nicht durch die <a href="/wiki/Wikipedia:Artikel" title="Wikipedia:Artikel">Mindestanforderungen an Artikel</a> und die <a href="/wiki/Wikipedia:Schnelll%C3%B6schantrag" title="Wikipedia:Schnelllöschantrag">Löschkriterien</a> beantwortet werden.</li></ul>
-</div>
-</div></div>
-</div>
+<ul><li>Dienstleistung/Produkt</li>
+<li>IT-Individualanwendung</li>
+<li>IT-Standardanwendung</li>
+<li>IT-Anwendung Weiterentwicklung</li>
+<li>IT-Infrastruktur</li>
+<li>Organisationsanpassung</li>
+<li>Dienstleistung/Produkt agil</li>
+<li>IT-Individualanwendung agil</li></ul>
+<div class="mw-heading mw-heading3"><h3 id="Hermes_Ausgabe_2022">Hermes Ausgabe 2022</h3><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=4" title="Abschnitt bearbeiten: Hermes Ausgabe 2022" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=4" title="Quellcode des Abschnitts bearbeiten: Hermes Ausgabe 2022"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Hermes Ausgabe 2022 bietet fünf Standardszenarien für Projekte mit verschiedenen Charakteristiken an:<sup id="cite&#95;ref-:4&#95;6-0" class="reference"><a href="#cite_note-:4-6"><span class="cite-bracket">&#91;</span>6<span class="cite-bracket">&#93;</span></a></sup>
+</p>
+<ul><li>Dienstleistung/Produkt Entwicklung</li>
+<li>Dienstleistung/Produkt Adaption</li>
+<li>IT-Entwicklung</li>
+<li>IT-Adaption</li>
+<li>Organisationsanpassung</li></ul>
+<div class="mw-heading mw-heading3"><h3 id="Individuelle_Szenarien">Individuelle Szenarien</h3><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=5" title="Abschnitt bearbeiten: Individuelle Szenarien" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=5" title="Quellcode des Abschnitts bearbeiten: Individuelle Szenarien"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Szenarien können angepasst oder individuell erstellt werden. Dazu gibt es vier grundlegende Möglichkeiten<sup id="cite&#95;ref-:1&#95;5-2" class="reference"><a href="#cite_note-:1-5"><span class="cite-bracket">&#91;</span>5<span class="cite-bracket">&#93;</span></a></sup>:
+</p>
+<ol><li>Module aus einem bestehenden Szenario entfernen.</li>
+<li>Aufgaben und Ergebnisse aus einem bestehenden Szenario entfernen.</li>
+<li>Ein zusätzliches Modul in ein Szenario integrieren.</li>
+<li>Aufgaben und Ergebnisse in ein Szenario integrieren.</li></ol>
+<div class="mw-heading mw-heading2"><h2 id="Ausbildung_und_Zertifizierung">Ausbildung und Zertifizierung</h2><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=6" title="Abschnitt bearbeiten: Ausbildung und Zertifizierung" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=6" title="Quellcode des Abschnitts bearbeiten: Ausbildung und Zertifizierung"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Schulungen können bei verschiedenen Seminaranbietern besucht werden. Für Hermes gibt es zwei Zertifizierungen für Personen.
+</p>
+<div class="mw-heading mw-heading3"><h3 id="Foundation_Level">Foundation Level</h3><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=7" title="Abschnitt bearbeiten: Foundation Level" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=7" title="Quellcode des Abschnitts bearbeiten: Foundation Level"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Das Foundation Level (deutsch: Grundlagen Level) ist ein Grundlagen Wissenstest zur <a href="/wiki/Projektmanagement" title="Projektmanagement">Projektmanagement</a>-Methodologie Hermes. Die Prüfung dauert eine Stunde und besteht aus 40 Multiple-Choice-Fragen. Die Themenbereiche umfassen die Hermes Grundlagen, Anwendungsbereich und Aufbau des Standardszenarios, Module des Standardszenarios und Projektorganisation (Rollen) des Standardszenarios. Als Zielgruppe für die Zertifizierung werden Projektmitarbeitende, Juniorprojektleiter, Entscheidungsträger, Auftraggeber und Projektcontroller genannt.<sup id="cite&#95;ref-7" class="reference"><a href="#cite_note-7"><span class="cite-bracket">&#91;</span>7<span class="cite-bracket">&#93;</span></a></sup>
+</p>
+<div class="mw-heading mw-heading3"><h3 id="Advanced_Level">Advanced Level</h3><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=8" title="Abschnitt bearbeiten: Advanced Level" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=8" title="Quellcode des Abschnitts bearbeiten: Advanced Level"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Das Advanced Level (deutsch: Fortgeschrittenes Level) ist ein Fortgeschrittener Wissenstest zur Projektmanagement-Methodologie Hermes. Die Prüfung besteht aus zwei Teilen. Beide Teile dauern je 60 Minuten (gültig für Prüfungen nach Lernzielen/Referenzhandbuch/Format 2019). Der erste Teil besteht aus 30 <a href="/wiki/Multiple_Choice" title="Multiple Choice">Multiple-Choice</a>-Fragen und der zweite aus 15 Multiple-Choice-Fragen mit Praxissituation. Die Themenbereiche umfassen die Hermes Grundlagen, Module IT-System, IT-Betrieb und IT-Migration der Standardszenarien, Module Projektgrundlagen und Projektführung des Standardszenarios und das Modul Projektsteuerung. Als Zielgruppe für die Zertifizierung werden Projektleiter, Projektmanager und Teilprojektleiter genannt.<sup id="cite&#95;ref-8" class="reference"><a href="#cite_note-8"><span class="cite-bracket">&#91;</span>8<span class="cite-bracket">&#93;</span></a></sup>
+</p>
+<div class="mw-heading mw-heading3"><h3 id="Advanced_Level_(Recertification)"><span id="Advanced_Level_.28Recertification.29"></span>Advanced Level (Recertification)</h3><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=9" title="Abschnitt bearbeiten: Advanced Level (Recertification)" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=9" title="Quellcode des Abschnitts bearbeiten: Advanced Level (Recertification)"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<p>Die Rezertifizierung erfolgt auf Antrag des Teilnehmers vor Ablauf des Zertifizierungszeitraums in der Regel frühestens ein Jahr vor Ablauf des Zertifikats.<sup id="cite&#95;ref-9" class="reference"><a href="#cite_note-9"><span class="cite-bracket">&#91;</span>9<span class="cite-bracket">&#93;</span></a></sup>
+</p><p>Um eine Rezertifizierung durchzuführen, sind folgende Anforderungen durch die Teilnehmer zu erfüllen:
+</p>
+<ol><li>Nachweis einer Veranstaltungsteilnahme zum Thema Projektmanagement und / oder Hermes und</li>
+<li>Nachweis von Weiterbildungseinheiten zum Thema Projektmanagement und / oder Hermes (mindestens 8 Unterrichtseinheiten von je 45 Minuten) und</li>
+<li>Berufserfahrung: Eine Rolle der Führung, Steuerung, Ausführung oder Wissensvermittlung gemäß Hermes innerhalb der Zertifizierungsphase (eine Beschreibung mit Bestätigung des Arbeit-/ Auftraggebers).</li></ol>
+<div class="mw-heading mw-heading2"><h2 id="Weblinks">Weblinks</h2><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=10" title="Abschnitt bearbeiten: Weblinks" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=10" title="Quellcode des Abschnitts bearbeiten: Weblinks"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<ul><li><a rel="nofollow" class="external text" href="https://www.isb.admin.ch/isb/de/home/themen/projektmanagement/hermes/ausbildung_zertifizierung.html">Ausbildung und Zertifizierung</a></li>
+<li><a rel="nofollow" class="external text" href="https://www.hermes.admin.ch/">HERMES – Die schweizerische Projektführungsmethode</a></li></ul>
+<div class="mw-heading mw-heading2"><h2 id="Einzelnachweise">Einzelnachweise</h2><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;veaction=edit&amp;section=11" title="Abschnitt bearbeiten: Einzelnachweise" class="mw-editsection-visualeditor"><span>Bearbeiten</span></a><span class="mw-editsection-divider"> | </span><a href="/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;action=edit&amp;section=11" title="Quellcode des Abschnitts bearbeiten: Einzelnachweise"><span>Quelltext bearbeiten</span></a><span class="mw-editsection-bracket">]</span></span></div>
+<ol class="references">
+<li id="cite&#95;note-1"><span class="mw-cite-backlink"><a href="#cite_ref-1">↑</a></span> <span class="reference-text"><span class="cite"><a rel="nofollow" class="external text" href="https://www.parlament.ch/centers/documents/de/ed-pa-aufsichtskommission-frueher-3-d.pdf"><i>Bericht der Geschäftsprüfungskommission des Ständerates vom 19. November 1998, <i>Einrichtung von Online-Verbindungen im Bereich des Polizeiwesens</i>.</i></a>&#32;parlament.ch&#44;<span class="Abrufdatum">&#32;abgerufen am 23.&#160;August 2015</span>.</span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Bericht+der+Gesch%C3%A4ftspr%C3%BCfungskommission+des+St%C3%A4nderates+vom+19.+November+1998%2C+%27%27Einrichtung+von+Online-Verbindungen+im+Bereich+des+Polizeiwesens%27%27&amp;rft.description=Bericht+der+Gesch%C3%A4ftspr%C3%BCfungskommission+des+St%C3%A4nderates+vom+19.+November+1998%2C+%27%27Einrichtung+von+Online-Verbindungen+im+Bereich+des+Polizeiwesens%27%27&amp;rft.identifier=https%3A%2F%2Fwww.parlament.ch%2Fcenters%2Fdocuments%2Fde%2Fed-pa-aufsichtskommission-frueher-3-d.pdf&amp;rft.publisher=parlament.ch">&#160;</span></span>
+</li>
+<li id="cite&#95;note-:3-2"><span class="mw-cite-backlink">↑ <sup><a href="#cite_ref-:3_2-0">a</a></sup> <sup><a href="#cite_ref-:3_2-1">b</a></sup></span> <span class="reference-text"><span class="cite"><i>Die Geschichte der Projektführungsmethode HERMES.</i>&#32;Informatiksteuerungsorgan des Bundes ISB,&#32;8.&#160;Januar 2020&#44;&#32;ehemals&#32;im&#32;<style data-mw-deduplicate="TemplateStyles:r250917974">.mw-parser-output .dewiki-iconexternal>a{background-position:center right!important;background-repeat:no-repeat!important}body.skin-minerva .mw-parser-output .dewiki-iconexternal>a{background-image:url("https://upload.wikimedia.org/wikipedia/commons/a/a4/OOjs_UI_icon_external-link-ltr-progressive.svg")!important;background-size:10px!important;padding-right:13px!important}body.skin-timeless .mw-parser-output .dewiki-iconexternal>a,body.skin-monobook .mw-parser-output .dewiki-iconexternal>a{background-image:url("https://upload.wikimedia.org/wikipedia/commons/3/30/MediaWiki_external_link_icon.svg")!important;padding-right:13px!important}body.skin-vector .mw-parser-output .dewiki-iconexternal>a{background-image:url("https://upload.wikimedia.org/wikipedia/commons/9/96/Link-external-small-ltr-progressive.svg")!important;background-size:0.857em!important;padding-right:1em!important}</style><span class="dewiki-iconexternal"><a class="external text" href="https://redirecter.toolforge.org/?url=https%3A%2F%2Fwww.isb.admin.ch%2Fdam%2Fisb%2Fde%2Fdokumente%2Fthemen%2Fhermes%2FDie_Geschichte_HERMES_2020.pdf.download.pdf%2FDie_Geschichte_HERMES_2020.pdf">Original</a></span>&#32;(nicht mehr online verfügbar)<span>;</span><span class="Abrufdatum">&#32;abgerufen am 11.&#160;August 2020</span>.<span style="display:none"><a rel="nofollow" class="external text" href="http://deadurl.invalid/https://www.isb.admin.ch/dam/isb/de/dokumente/themen/hermes/Die_Geschichte_HERMES_2020.pdf.download.pdf/Die_Geschichte_HERMES_2020.pdf">@1</a></span><span style="display:none"><a rel="nofollow" class="external text" href="https://www.isb.admin.ch/dam/isb/de/dokumente/themen/hermes/Die_Geschichte_HERMES_2020.pdf.download.pdf/Die_Geschichte_HERMES_2020.pdf">@2</a></span><span style="display:none"><a href="/w/index.php?title=Vorlage:Toter_Link/www.isb.admin.ch&amp;action=edit&amp;redlink=1" class="new" title="Vorlage:Toter Link/www.isb.admin.ch (Seite nicht vorhanden)">Vorlage:Toter Link/www.isb.admin.ch</a></span>&#32;<small>(<a href="/wiki/Wikipedia:Defekte_Weblinks" title="Wikipedia:Defekte Weblinks">Seite nicht mehr abrufbar</a>. <a rel="nofollow" class="external text" href="http://timetravel.mementoweb.org/list/2010/https://www.isb.admin.ch/dam/isb/de/dokumente/themen/hermes/Die_Geschichte_HERMES_2020.pdf.download.pdf/Die_Geschichte_HERMES_2020.pdf">Suche in Webarchiven</a>)</small></span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Die+Geschichte+der+Projektf%C3%BChrungsmethode+HERMES&amp;rft.description=Die+Geschichte+der+Projektf%C3%BChrungsmethode+HERMES&amp;rft.identifier=https%3A%2F%2Fwww.isb.admin.ch%2Fdam%2Fisb%2Fde%2Fdokumente%2Fthemen%2Fhermes%2FDie&#95;Geschichte&#95;HERMES&#95;2020.pdf.download.pdf%2FDie&#95;Geschichte&#95;HERMES&#95;2020.pdf&amp;rft.publisher=Informatiksteuerungsorgan+des+Bundes+ISB&amp;rft.date=2020-01-08&amp;rft.language=de">&#160;</span></span>
+</li>
+<li id="cite&#95;note-3"><span class="mw-cite-backlink"><a href="#cite_ref-3">↑</a></span> <span class="reference-text"><span class="cite"><a rel="nofollow" class="external text" href="https://gouvernement.lu/fr/actualites/toutes_actualites/articles/2006/04/26wiseler_quapital.html"><i>Claude Wiseler présente le programme Quapital (Qualité des projets d'implémentation des technologies de l'information et de la communication dans l'administration luxembourgeoise).</i></a>&#32;25.&#160;April 2006&#44;<span class="Abrufdatum">&#32;abgerufen am 30.&#160;April 2020</span>&#32;(französisch).</span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Claude+Wiseler+pr%C3%A9sente+le+programme+Quapital+%28Qualit%C3%A9+des+projets+d%27impl%C3%A9mentation+des+technologies+de+l%27information+et+de+la+communication+dans+l%27administration+luxembourgeoise%29&amp;rft.description=Claude+Wiseler+pr%C3%A9sente+le+programme+Quapital+%28Qualit%C3%A9+des+projets+d%27impl%C3%A9mentation+des+technologies+de+l%27information+et+de+la+communication+dans+l%27administration+luxembourgeoise%29&amp;rft.identifier=https%3A%2F%2Fgouvernement.lu%2Ffr%2Factualites%2Ftoutes&#95;actualites%2Farticles%2F2006%2F04%2F26wiseler&#95;quapital.html&amp;rft.date=2006-04-25&amp;rft.language=fr">&#160;</span></span>
+</li>
+<li id="cite&#95;note-4"><span class="mw-cite-backlink"><a href="#cite_ref-4">↑</a></span> <span class="reference-text"><span class="cite"><a rel="nofollow" class="external text" href="https://www.youtube.com/watch?feature=player_embedded&amp;v=o3Pz5O_mzmA"><i>Trailer zur Version 5.</i></a><span class="Abrufdatum">&#32;Abgerufen am 7.&#160;Mai 2014</span>.</span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Trailer+zur+Version+5&amp;rft.description=Trailer+zur+Version+5&amp;rft.identifier=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Ffeature%3Dplayer&#95;embedded%26v%3Do3Pz5O&#95;mzmA">&#160;</span></span>
+</li>
+<li id="cite&#95;note-:1-5"><span class="mw-cite-backlink">↑ <sup><a href="#cite_ref-:1_5-0">a</a></sup> <sup><a href="#cite_ref-:1_5-1">b</a></sup> <sup><a href="#cite_ref-:1_5-2">c</a></sup></span> <span class="reference-text"><span class="cite"><a rel="nofollow" class="external text" href="https://www.hermes.admin.ch/de/projektmanagement/verstehen/szenarien.html"><i>Szenarien.</i></a><span class="Abrufdatum">&#32;Abgerufen am 22.&#160;Juli 2020</span>.</span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Szenarien&amp;rft.description=Szenarien&amp;rft.identifier=https%3A%2F%2Fwww.hermes.admin.ch%2Fde%2Fprojektmanagement%2Fverstehen%2Fszenarien.html">&#160;</span></span>
+</li>
+<li id="cite&#95;note-:4-6"><span class="mw-cite-backlink"><a href="#cite_ref-:4_6-0">↑</a></span> <span class="reference-text">Hermes Referenzhandbuch – Projektmanagement, Ausgabe 2022</span>
+</li>
+<li id="cite&#95;note-7"><span class="mw-cite-backlink"><a href="#cite_ref-7">↑</a></span> <span class="reference-text"><span class="cite"><a rel="nofollow" class="external text" href="https://www.tuev-sued.ch/ch-de/ueber-tuev-sued/tuev-sued-in-der-schweiz/examination-institute/hermes-5-deutsche-version/hermes-5-foundation"><i>Hermes Foundation.</i></a><span class="Abrufdatum">&#32;Abgerufen am 6.&#160;Januar 2020</span>.</span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Hermes+Foundation&amp;rft.description=Hermes+Foundation&amp;rft.identifier=https%3A%2F%2Fwww.tuev-sued.ch%2Fch-de%2Fueber-tuev-sued%2Ftuev-sued-in-der-schweiz%2Fexamination-institute%2Fhermes-5-deutsche-version%2Fhermes-5-foundation&amp;rft.language=de">&#160;</span></span>
+</li>
+<li id="cite&#95;note-8"><span class="mw-cite-backlink"><a href="#cite_ref-8">↑</a></span> <span class="reference-text"><span class="cite"><a rel="nofollow" class="external text" href="https://www.tuev-sued.ch/ch-de/ueber-tuev-sued/tuev-sued-in-der-schweiz/examination-institute/hermes-5-deutsche-version/hermes-5-advanced"><i>Hermes Advanced.</i></a><span class="Abrufdatum">&#32;Abgerufen am 6.&#160;Januar 2020</span>.</span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Hermes+Advanced&amp;rft.description=Hermes+Advanced&amp;rft.identifier=https%3A%2F%2Fwww.tuev-sued.ch%2Fch-de%2Fueber-tuev-sued%2Ftuev-sued-in-der-schweiz%2Fexamination-institute%2Fhermes-5-deutsche-version%2Fhermes-5-advanced&amp;rft.language=de">&#160;</span></span>
+</li>
+<li id="cite&#95;note-9"><span class="mw-cite-backlink"><a href="#cite_ref-9">↑</a></span> <span class="reference-text"><span class="cite"><a rel="nofollow" class="external text" href="https://www.tuev-sued.ch/ch-de/ueber-tuev-sued/tuev-sued-in-der-schweiz/examination-institute/hermes-5-deutsche-version/hermes-5-advanced-recertification"><i>Hermes Advanced Recertification.</i></a><span class="Abrufdatum">&#32;Abgerufen am 6.&#160;Januar 2020</span>.</span><span style="display: none;" class="Z3988" title="ctx&#95;ver=Z39.88-2004&amp;rft&#95;val&#95;fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr&#95;id=info%3Asid%2Fde.wikipedia.org%3AHermes+%28Projektmanagementmethode%29&amp;rft.title=Hermes+Advanced+Recertification&amp;rft.description=Hermes+Advanced+Recertification&amp;rft.identifier=https%3A%2F%2Fwww.tuev-sued.ch%2Fch-de%2Fueber-tuev-sued%2Ftuev-sued-in-der-schweiz%2Fexamination-institute%2Fhermes-5-deutsche-version%2Fhermes-5-advanced-recertification&amp;rft.language=de">&#160;</span></span>
+</li>
+</ol>
+<!--
+NewPP limit report
+Parsed by mw‐web.eqiad.main‐6947d99787‐m7r4l
+Cached time: 20260301152658
+Cache expiry: 2592000
+Reduced expiry: false
+Complications: [show‐toc]
+CPU time usage: 0.187 seconds
+Real time usage: 0.231 seconds
+Preprocessor visited node count: 2092/1000000
+Revision size: 8057/2097152 bytes
+Post‐expand include size: 27816/2097152 bytes
+Template argument size: 9680/2097152 bytes
+Highest expansion depth: 18/100
+Expensive parser function count: 2/500
+Unstrip recursion depth: 1/20
+Unstrip post‐expand size: 12941/5000000 bytes
+Lua time usage: 0.082/10.000 seconds
+Lua memory usage: 3010005/52428800 bytes
+Number of Wikibase entities loaded: 0/500
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  200.300      1 -total
+ 99.71%  199.718      8 Vorlage:Internetquelle
+ 14.27%   28.577      8 Vorlage:Str_len
+  7.32%   14.658      1 Vorlage:Referrer
+  6.15%   12.327      1 Vorlage:IconExternal
+  4.54%    9.088      1 Vorlage:Toter_Link
+  1.80%    3.599      1 Vorlage:Toter_Link/Core
+-->
+
+<!-- Saved in parser cache with key dewiki:stable-pcache:8220636:|#|:idhash:canonical and timestamp 20260301152658 and revision id 257327612. Rendering was triggered because: unknown
+ -->
 </div><noscript><img src="https://de.wikipedia.org/wiki/Special:CentralAutoLogin/start?useformat=desktop&amp;type=1x1&amp;usesul3=1" alt="" width="1" height="1" style="border: none; position: absolute;"></noscript>
-<div class="printfooter" data-nosnippet="">Abgerufen von „<a dir="ltr" href="https://de.wikipedia.org/wiki/Hermes_(Projektsteuerungsmethode)">https://de.wikipedia.org/wiki/Hermes_(Projektsteuerungsmethode)</a>“</div></div>
-					<div id="catlinks" class="catlinks catlinks-allhidden" data-mw-interface=""></div>
+<div class="printfooter" data-nosnippet="">Abgerufen von „<a dir="ltr" href="https://de.wikipedia.org/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;oldid=257327612">https://de.wikipedia.org/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;oldid=257327612</a>“</div></div>
+					<div id="catlinks" class="catlinks" data-mw-interface=""><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Wikipedia:Kategorien" title="Wikipedia:Kategorien">Kategorie</a>: <ul><li><a href="/wiki/Kategorie:Projektmanagement" title="Kategorie:Projektmanagement">Projektmanagement</a></li></ul></div><div id="mw-hidden-catlinks" class="mw-hidden-catlinks mw-hidden-cats-hidden">Versteckte Kategorie: <ul><li><a href="/wiki/Kategorie:Wikipedia:Weblink_offline" title="Kategorie:Wikipedia:Weblink offline">Wikipedia:Weblink offline</a></li></ul></div></div>
 				</div>
 			</main>
 
@@ -492,6 +791,11 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 <footer id="footer" class="mw-footer" >
 	<ul id="footer-info">
+	<li id="footer-info-lastmod"> Diese Seite wurde zuletzt am 24. Juni 2025 um 13:44 Uhr bearbeitet.</li>
+	<li id="footer-info-copyright"><div id="footer-info-copyright-stats" class="noprint"><a rel="nofollow" class="external text" href="https://pageviews.wmcloud.org/?pages=Hermes_(Projektmanagementmethode)&amp;project=de.wikipedia.org">Abrufstatistik</a>&#160;· <a rel="nofollow" class="external text" href="https://xtools.wmcloud.org/authorship/de.wikipedia.org/Hermes_(Projektmanagementmethode)?uselang=de">Autoren</a> </div><div id="footer-info-copyright-separator"><br /></div><div id="footer-info-copyright-info">
+<p>Der Text ist unter der Lizenz <a rel="nofollow" class="external text" href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">„Creative-Commons Namensnennung – Weitergabe unter gleichen Bedingungen“</a> verfügbar; Informationen zu den Urhebern und zum Lizenzstatus eingebundener Mediendateien (etwa Bilder oder Videos) können im Regelfall durch Anklicken dieser abgerufen werden. Möglicherweise unterliegen die Inhalte jeweils zusätzlichen Bedingungen. Durch die Nutzung dieser Website erklären Sie sich mit den <span class="plainlinks"><a class="external text" href="https://foundation.wikimedia.org/wiki/Policy:Terms_of_Use/de">Nutzungsbedingungen</a> und der <a class="external text" href="https://foundation.wikimedia.org/wiki/Policy:Privacy_policy/de">Datenschutzrichtlinie</a></span> einverstanden.<br />
+</p>
+Wikipedia® ist eine eingetragene Marke der Wikimedia Foundation Inc.</div></li>
 </ul>
 
 	<ul id="footer-places">
@@ -503,7 +807,7 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 	<li id="footer-places-developers"><a href="https://developer.wikimedia.org">Entwickler</a></li>
 	<li id="footer-places-statslink"><a href="https://stats.wikimedia.org/#/de.wikipedia.org">Statistiken</a></li>
 	<li id="footer-places-cookiestatement"><a href="https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Cookie_statement">Stellungnahme zu Cookies</a></li>
-	<li id="footer-places-mobileview"><a href="//de.wikipedia.org/w/index.php?title=Hermes_(Projektsteuerungsmethode)&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile Ansicht</a></li>
+	<li id="footer-places-mobileview"><a href="//de.wikipedia.org/w/index.php?title=Hermes_(Projektmanagementmethode)&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile Ansicht</a></li>
 </ul>
 
 	<ul id="footer-icons" class="noprint">
@@ -546,7 +850,23 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 			</div>
 		</div>
 		<div class="vector-sticky-header-context-bar">
-				<div class="vector-sticky-header-context-bar-primary" aria-hidden="true" ><span lang="de" dir="ltr"><span class="mw-page-title-main">Hermes (Projektsteuerungsmethode)</span></span></div>
+				<nav aria-label="Inhaltsverzeichnis" class="vector-toc-landmark">
+
+					<div id="vector-sticky-header-toc" class="vector-dropdown mw-portlet mw-portlet-sticky-header-toc vector-sticky-header-toc vector-button-flush-left"  >
+						<input type="checkbox" id="vector-sticky-header-toc-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-sticky-header-toc" class="vector-dropdown-checkbox "  aria-label="Inhaltsverzeichnis umschalten"  >
+						<label id="vector-sticky-header-toc-label" for="vector-sticky-header-toc-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-listBullet mw-ui-icon-wikimedia-listBullet"></span>
+
+<span class="vector-dropdown-label-text">Inhaltsverzeichnis umschalten</span>
+						</label>
+						<div class="vector-dropdown-content">
+
+						<div id="vector-sticky-header-toc-unpinned-container" class="vector-unpinned-container">
+						</div>
+
+						</div>
+					</div>
+			</nav>
+				<div class="vector-sticky-header-context-bar-primary" aria-hidden="true" ><span class="mw-page-title-main">Hermes (Projektmanagementmethode)</span></div>
 			</div>
 		</div>
 		<div class="vector-sticky-header-end" aria-hidden="true">
@@ -581,7 +901,11 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 			</a>
 		</div>
 			<div class="vector-sticky-header-buttons">
-				<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--action-progressive" id="ca-addsection-sticky-header" tabindex="-1" data-event-name="addsection-sticky-header"><span class="vector-icon mw-ui-icon-speechBubbleAdd-progressive mw-ui-icon-wikimedia-speechBubbleAdd-progressive"></span>
+				<button class="cdx-button cdx-button--weight-quiet mw-interlanguage-selector" id="p-lang-btn-sticky-header" tabindex="-1" data-event-name="ui.dropdown-p-lang-btn-sticky-header"><span class="vector-icon mw-ui-icon-wikimedia-language mw-ui-icon-wikimedia-wikimedia-language"></span>
+
+<span>5 Sprachen</span>
+			</button>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--action-progressive" id="ca-addsection-sticky-header" tabindex="-1" data-event-name="addsection-sticky-header"><span class="vector-icon mw-ui-icon-speechBubbleAdd-progressive mw-ui-icon-wikimedia-speechBubbleAdd-progressive"></span>
 
 <span>Abschnitt hinzufügen</span>
 			</a>
@@ -598,6 +922,7 @@ RLSTATE={"ext.gadget.citeRef":"ready","ext.gadget.defaultPlainlinks":"ready","ex
 
 	</ul>
 </div>
-<script>(RLQ=window.RLQ||[]).push(function(){mw.log.warn("This page is using the deprecated ResourceLoader module \"mediawiki.ui.button\".\n[1.41] Please use Codex. See migration guidelines: https://www.mediawiki.org/wiki/Codex/Migrating_from_MediaWiki_UI");mw.config.set({"wgHostname":"mw-web.codfw.main-5bc88d54cb-2xgl2","wgBackendResponseTime":126,"wgPageParseReport":{"limitreport":{"cputime":"0.052","walltime":"0.057","ppvisitednodes":{"value":132,"limit":1000000},"revisionsize":{"value":91,"limit":2097152},"postexpandincludesize":{"value":6427,"limit":2097152},"templateargumentsize":{"value":52,"limit":2097152},"expansiondepth":{"value":8,"limit":100},"expensivefunctioncount":{"value":3,"limit":500},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":10316,"limit":5000000},"entityaccesscount":{"value":0,"limit":500},"timingprofile":["100.00%   50.049      1 MediaWiki:Noarticletext-0","100.00%   50.049      1 -total","  2.80%    1.401      6 Vorlage:De-formal"]},"scribunto":{"limitreport-timeusage":{"value":"0.002","limit":"10.000"},"limitreport-memusage":{"value":628918,"limit":52428800}},"cachereport":{"origin":"mw-web.codfw.main-5bc88d54cb-2xgl2","timestamp":"20260314123159","ttl":2592000,"transientcontent":false}}});});</script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgHostname":"mw-web.codfw.canary-974f8b86-5qpfx","wgBackendResponseTime":168,"wgPageParseReport":{"limitreport":{"cputime":"0.187","walltime":"0.231","ppvisitednodes":{"value":2092,"limit":1000000},"revisionsize":{"value":8057,"limit":2097152},"postexpandincludesize":{"value":27816,"limit":2097152},"templateargumentsize":{"value":9680,"limit":2097152},"expansiondepth":{"value":18,"limit":100},"expensivefunctioncount":{"value":2,"limit":500},"unstrip-depth":{"value":1,"limit":20},"unstrip-size":{"value":12941,"limit":5000000},"entityaccesscount":{"value":0,"limit":500},"timingprofile":["100.00%  200.300      1 -total"," 99.71%  199.718      8 Vorlage:Internetquelle"," 14.27%   28.577      8 Vorlage:Str_len","  7.32%   14.658      1 Vorlage:Referrer","  6.15%   12.327      1 Vorlage:IconExternal","  4.54%    9.088      1 Vorlage:Toter_Link","  1.80%    3.599      1 Vorlage:Toter_Link/Core"]},"scribunto":{"limitreport-timeusage":{"value":"0.082","limit":"10.000"},"limitreport-memusage":{"value":3010005,"limit":52428800}},"cachereport":{"origin":"mw-web.eqiad.main-6947d99787-m7r4l","timestamp":"20260301152658","ttl":2592000,"transientcontent":false}}});});</script>
+<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"Article","name":"Hermes (Projektmanagementmethode)","url":"https:\/\/de.wikipedia.org\/wiki\/Hermes_(Projektmanagementmethode)","sameAs":"http:\/\/www.wikidata.org\/entity\/Q1431655","mainEntity":"http:\/\/www.wikidata.org\/entity\/Q1431655","author":{"@type":"Organization","name":"Autoren der Wikimedia-Projekte"},"publisher":{"@type":"Organization","name":"Wikimedia Foundation, Inc.","logo":{"@type":"ImageObject","url":"https:\/\/www.wikimedia.org\/static\/images\/wmf-hor-googpub.png"}},"datePublished":"2006-02-13T16:53:59Z","headline":"offener Standard zur F\u00fchrung und Abwicklung von Informatikprojekten"}</script>
 </body>
 </html>

--- a/specifications/PRINCE2/prince2.md
+++ b/specifications/PRINCE2/prince2.md
@@ -1,0 +1,274 @@
+![](//upload.wikimedia.org/wikipedia/en/thumb/b/b4/Ambox_important.svg/40px-Ambox_important.svg.png)| This article **contains[promotional content](/wiki/Wikipedia:What_Wikipedia_is_not#Wikipedia_is_not_a_soapbox_or_means_of_promotion "Wikipedia:What Wikipedia is not")**. Please help [improve it](https://en.wikipedia.org/w/index.php?title=PRINCE2&action=edit) by removing [promotional language](/wiki/Wikipedia:Spam "Wikipedia:Spam") and inappropriate [external links](/wiki/Wikipedia:External_links#Advertising_and_conflicts_of_interest "Wikipedia:External links"), and by adding encyclopedic text written from a [neutral point of view](/wiki/Wikipedia:Neutral_point_of_view "Wikipedia:Neutral point of view").See our **[advice if the article is about you](/wiki/Wikipedia:About_you "Wikipedia:About you")** and read our **[scam warning](/wiki/Wikipedia:Scam_warning "Wikipedia:Scam warning") in case someone asks for money** to edit this article. _( March 2021)__([Learn how and when to remove this message](/wiki/Help:Maintenance_template_removal "Help:Maintenance template removal"))_
+---|---
+
+[![](//upload.wikimedia.org/wikipedia/commons/thumb/a/a2/PRINCE2_-_Project_Management_Methodology.png/330px-PRINCE2_-_Project_Management_Methodology.png)](/wiki/File:PRINCE2_-_Project_Management_Methodology.png)PRINCE2 – structure
+
+**PRINCE2** (**PRojects IN Controlled Environments**) is a structured [project management](/wiki/Project_management "Project management") method[1] and practitioner certification programme. PRINCE2 emphasises dividing projects into manageable and controllable stages.
+
+It is adopted in many countries worldwide, including the UK, Western European countries, and Australia.[2] PRINCE2 training is available in many languages.[3]
+
+PRINCE2 was developed as a [UK government](/wiki/Cabinet_Office "Cabinet Office") standard for information systems projects. In July 2013, ownership of the rights to PRINCE2 were transferred from HM [Cabinet Office](/wiki/Cabinet_Office "Cabinet Office") to [AXELOS Ltd](/wiki/AXELOS "AXELOS"), a [joint venture](/wiki/Joint_venture "Joint venture") by the [Cabinet Office](/wiki/Cabinet_Office "Cabinet Office") and [Capita](/wiki/Capita "Capita"), with 49% and 51% stakes respectively.[4]
+
+In 2021, PRINCE2 was transferred to [PeopleCert](/w/index.php?title=PeopleCert&action=edit&redlink=1 "PeopleCert \(page does not exist\)") during their acquisition of AXELOS.[5]
+
+## History
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=1 "Edit section: History")]
+
+PRINCE was derived from an earlier method called PROMPT II (Project Resource Organisation Management Planning Techniques). In 1989 the [Central Computer and Telecommunications Agency](/wiki/Central_Computer_and_Telecommunications_Agency "Central Computer and Telecommunications Agency") (CCTA) adopted a version of PROMPT II as a UK Government standard for information systems (IT) project management. They gave it the name 'PRINCE', which originally stood for "**PR** OMPT II **IN** the **C** CTA **E** nvironment". PRINCE was renamed in a [civil service](/wiki/Civil_service "Civil service") competition as an acronym for "**PR** ojects **IN** **C** ontrolled **E** nvironments". PRINCE2 is the second edition of the earlier PRINCE method which was initially announced and developed in 1989 by the [Central Computer and Telecommunications Agency](/wiki/Central_Computer_and_Telecommunications_Agency "Central Computer and Telecommunications Agency") (CCTA), a UK government support agency.[6] PRINCE2 was released in 1996 as a generic [project management](/wiki/Project_management "Project management") method.[7]
+
+Since then, PRINCE2 became increasingly popular[8] and is now a _de facto_ standard for project management in many UK government departments and across the [United Nations system](/wiki/United_Nations_system "United Nations system").
+
+There have been three major revisions of PRINCE2 since its launch in 1996: "PRINCE2:2009 Refresh" in 2009, and "PRINCE2 2017 Update" in 2017. The justification for the 2017 update was the evolution in practical business practices and feedback from PRINCE2 practitioners in the actual project environment.[9] More recently, in 2023 AXELOS launched PRINCE2 7 - the 7th edition - which is described below.
+
+## Overview of PRINCE2
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=2 "Edit section: Overview of PRINCE2")]
+
+### Seven aspects of project performance
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=3 "Edit section: Seven aspects of project performance")]
+
+These aspects are also called **tolerances** or **performance goals**. Tolerances define the delegated levels of authority which are set by a higher level of management to a lower level. The management level responsible must manage within the tolerances provided only as long as they are not forecast to be exceeded. Otherwise they are deemed to be an exception which requires escalating to the management level which delegated them. This way of managing is known as 'management by exception' and is one of the principles of PRINCE2. By managing in this way, it saves the time of senior management. In some organisations tolerances can be [key performance indicators](/wiki/Performance_indicator "Performance indicator") (KPIs). In the following table project level tolerances are summarised:[10]
+
+Tolerance type | Defined in management product | Example
+---|---|---
+Scope | Project/stage plan, work package description | The printer must print documents in black/white, and should also print in colour.
+Timescale | Project/stage plan, work package description | The work must be delivered within 2–3 months.
+Risk | Business case, stage plan, work package description | Printer might not work if it is exposed to water.
+Quality | [Project product description, product description](/wiki/Product_description "Product description") | Printer should not suffer mechanical failure when printing between 2,000 and 10,000 pages.
+Benefits | [Business case](/wiki/Business_case "Business case"), stage plan | Sales should enable a net profit of between £200,000 to £400,000.
+Cost | Project/stage plan, work package description | The cost of the project should be between £100,000 and £150,000.
+Sustainability  | Business case, stage plan, work package description, product description  | Toner for the printer must be carbon neutral.
+Management level | Delegated tolerance level | Escalated issue/exception
+---|---|---
+Business layer | Project tolerance | —N/a
+Project board | Stage tolerance | Project exception
+Project manager | Work package tolerance | Stage exception
+Team manager | —N/a | Issue
+
+### Seven principles (why, or guidelines to follow)
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=4 "Edit section: Seven principles \(why, or guidelines to follow\)")]
+
+PRINCE2 is based on seven principles and these cannot be tailored. The PRINCE2 principles can be described as a [mindset](/wiki/Mindset "Mindset") that keeps the project aligned with the PRINCE2 methodology. If a project does not adhere to these principles, it is not being managed using PRINCE2.
+
+  1. **Ensure continued business justification** : The business case is the most important document, and is updated at every stage of the project to ensure that the project is still viable. Early termination can occur if this ceases to be the case.
+  2. **Learn from experience** : Each project maintains a lessons log and projects should continually refer to their own and to previous and concurrent projects' lesson logs to avoid reinventing wheels. Unless lessons provoke change, they are only lessons identified (not learned).
+  3. **Define roles, responsibilities, and relationships** : Roles are separated from individuals, who may take on multiple roles or share a role. Roles in PRINCE2 are structured in four levels (corporate or programme management, project board, project manager level and team level). Project Management Team contains the last three, where all primary stakeholders (business, user, supplier) need to be presented.
+  4. **Manage by stages** : The project is planned and controlled on a stage by stage basis. Moving between stages includes updating the business case, risks, overall plan, and detailed next-stage plan in the light of new evidence.
+  5. **Manage by exception** : A PRINCE2 project has defined tolerances (6 aspects above) for each project objective, to establish limits of delegated authority. If a management level forecasts that these tolerances are exceeded (e.g. time of a management stage will be longer than the estimated time in the current management stage), it is escalated to the next management level for a decision how to proceed.
+  6. **Focus on products** : A PRINCE2 project focuses on the definition and delivery of the products, in particular their **quality requirements**.
+  7. **Tailor to suit the project** : PRINCE2 is tailored to suit the project environment, size, complexity, importance, time capability and risk. Tailoring is the first activity in the process **initiating a project** and reviewed for each stage.
+
+Not every aspect of PRINCE2 will be applicable to every project, thus every process has a note on [scalability](/wiki/Scalability "Scalability"). This provides guidance to the project manager (and others involved in the project) as to _how much_ of the process to apply. The positive aspect of this is that PRINCE2 can be tailored to the needs of a particular project. The negative aspect is that many of the essential elements of PRINCE2 can be omitted sometimes resulting in a PINO project – PRINCE in Name Only
+
+### Seven PRINCE2 practices and the management products used to support each practice
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=5 "Edit section: Seven PRINCE2 practices and the management products used to support each practice")]
+
+Practice | Management products which support the practice
+---|---
+Business case |
+
+  * Business case
+  * Benefits management approach
+  * Sustainability management approach
+
+Organizing |
+
+  * Communication management approach
+  * Project management team structure
+  * Role descriptions
+
+Quality |
+
+  * Product description
+  * Quality management approach
+  * Quality register
+  * Product register
+
+Plans |
+
+  * Plan (project, stage, team, exception)
+  * Project product description
+  * Work package description
+
+Risk |
+
+  * Risk management approach
+  * Risk register
+
+Issues |
+
+  * Issue management approach
+  * Issue register
+  * Issue report
+
+Progress |
+
+  * Digital and data management approach
+  * Daily log
+  * Lessons log
+  * Checkpoint report
+  * Highlight report
+  * Lessons report
+  * Exception report
+  * End stage report
+  * End project report
+
+### Seven processes (who does what and when from start to finish)
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=6 "Edit section: Seven processes \(who does what and when from start to finish\)")]
+
+  1. Starting up a project, in which the [project team](/wiki/Project_team "Project team") is appointed including an [executive](/wiki/Project_executive "Project executive") and a [project manager](/wiki/Project_manager "Project manager"), and a project brief is produced.
+  2. Initiating a project, in which the business case is refined and [project initiation documentation](/wiki/Project_Initiation_Documentation "Project Initiation Documentation") is assembled.
+  3. Directing a project, in which the project board directs the project manager and oversees the project.
+  4. Controlling a stage, in which the project manager authorises [work packages](/wiki/Work_package "Work package") to team managers, manages issues and risks, and reports progress to the project board.
+  5. Managing product delivery, which provides an interface between the project manager and the team manager(s) by placing formal requirements on accepting, executing and delivering project work.[11]
+  6. [Managing stage boundaries](/wiki/Managing_stage_boundaries "Managing stage boundaries"), in which the project manager prepares the information for the project board to decide whether to authorise the next stage or close the project.
+  7. Closing a project, in which the project is the formally closed, follow-on actions are documented and assigned, lessons are learned, and benefits are evaluated.
+
+### People in PRINCE2
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=7 "Edit section: People in PRINCE2")]
+
+The 7th edition of PRINCE2 introduced a major new aspect to the method - the role of people. The purpose of a project is to deliver change, which will affect the people who perform business as usual (BAU) activities. How well the project delivers the change, depends on the capabilities of the project team, the strength of the relationships between them, and the people impacted by the change. For these reasons, PRINCE2 recommends that projects must incorporate change management to be able to successfully implement the change into the organization.
+
+## Integration with other techniques
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=8 "Edit section: Integration with other techniques")]
+
+The management products described by PRINCE2 are only used for the "high-level" management of the project. Within its [tasks](/wiki/Task_\(project_management\) "Task \(project management\)"), task managers must still decide on their own project management framework. Some suggestions given in the PRINCE2 manual are [product based planning](/wiki/Product_based_planning "Product based planning"), [change control](/wiki/Change_control "Change control"), quality review technique, [Kanban boards](/wiki/Kanban_board "Kanban board"), [Gantt charts](/wiki/Gantt_chart "Gantt chart"), [PERT charts](/wiki/PERT_chart "PERT chart") and [critical path](/wiki/Critical_path_method "Critical path method") analysis.
+
+PRINCE2 can also be used to manage projects that use [agile software development](/wiki/Agile_software_development "Agile software development") methods.[12]
+
+### Quality review technique
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=9 "Edit section: Quality review technique")]
+
+See also: [Quality assurance](/wiki/Quality_assurance "Quality assurance")
+
+The quality review technique ensures a project's products are of the required standard (i.e. meet defined quality criteria). This takes place in a quality review meeting, which identifies errors in the product. The quality review meeting will not attempt to solve the problems it identifies. The meeting brings together people who have an interest in the project's outputs (or products) and people on the project team able to address issues identified.
+
+## History of PRINCE2 editions
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=10 "Edit section: History of PRINCE2 editions")]
+
+Below is a list of all the editions of PRINCE2. As of 1 January 2020, "PRINCE2 2017" was renamed "PRINCE2 6th Edition". Also, the previous edition, "PRINCE2 2009" was renamed "PRINCE2 5th Edition". There were no other changes except the name of the brand. The reason for the name change was to "ensure the format of the name is aligned with that used by other frameworks within the project management industry".[13] As list of all versions of PRINCE2 are printed in the cover of the PRINCE2 manual:
+
+Release year | Release name | Release edition
+---|---|---
+1996 | PRINCE2 1996 | PRINCE2 1st Edition*
+1998 | PRINCE2 1998 | PRINCE2 2nd Edition*
+2002 | PRINCE2 2002 | PRINCE2 3rd Edition*
+2005 | PRINCE2 2005 | PRINCE2 4th Edition*
+2009 | PRINCE2 2009 | PRINCE2 5th Edition
+2017 | PRINCE2 2017 | PRINCE2 6th Edition
+2023 | PRINCE2 2023 | PRINCE2 7th Edition
+
+(*nth names added for other editions in order for context, but they were not referred to these names originally. However, they are referenced as such in the PRINCE2 manual cover page.)
+
+## Differences between 2009 and 2017 versions of PRINCE2 Manual [_[clarification needed](/wiki/Wikipedia:Please_clarify "Wikipedia:Please clarify")_]
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=11 "Edit section: Differences between 2009 and 2017 versions of PRINCE2 Manual \[clarification needed\]")]
+
+2009 version | 2017 version[10] | Type
+---|---|---
+Benefits review plan | Benefits management approach | Management product
+Communication management strategy | Communication management approach | Management product
+Risk management strategy | Risk management approach | Management product
+Quality management strategy | Quality management approach | Management product
+Configuration management strategy | Change control approach | Management product
+
+## New aspects introduced in the 7th edition[_[clarification needed](/wiki/Wikipedia:Please_clarify "Wikipedia:Please clarify")_]
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=12 "Edit section: New aspects introduced in the 7th edition\[clarification needed\]")]
+
+PRINCE2 7th edition
+---
+Performance target for sustainability
+Renaming of some principles
+Renaming of themes to practices
+Change practice now called Issues
+Configuration management strategy
+Introduction of new management products: sustainability management approach, digital and data management approach, project log.
+
+## Advantages and criticisms
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=13 "Edit section: Advantages and criticisms")]
+
+Some of the advertised benefits of PRINCE2 are: increased quality of the finished products, efficient control of resources, avoidance of either "heroic" (under-regulated) or "mechanistic" (over-regulated) working, and increased confidence among the project team.
+
+PRINCE2 is sometimes considered inappropriate for small projects or where requirements are expected to change, due to the work required in creating and maintaining documents, logs and lists. The deliverable structure may also lead to focus on producing deliverables for their own sake, to "tick the boxes" rather than do more useful work.[_[citation needed](/wiki/Wikipedia:Citation_needed "Wikipedia:Citation needed")_]
+
+The general response of PRINCE2's authors to criticism has been to point out that the methodology is scalable and can be tailored to suit the specific requirements and constraints of the project and the environment.[14] This strong emphasis on tailoring has led some users to complain that PRINCE2 is [unfalsifiable](/wiki/Falsifiable "Falsifiable"), i.e. it is impossible to tell whether PRINCE2 "works" or constitutes "best practice" if any problems encountered with a project can be blamed on inappropriate application of PRINCE2 rather than on PRINCE2 itself.
+
+The experiences of the [Blair government](/wiki/Premiership_of_Tony_Blair "Premiership of Tony Blair") in the UK between 1997 and 2007 (and of subsequent UK governments) arguably undermine PRINCE2's claim to be "best practice", given the string of high-profile failed IT projects charged to the taxpayer during that time,[15][16][17] and the controversy surrounding the financial relationship between the Blair government and PRINCE2's co-owners [Capita](/wiki/Capita "Capita").[18][19] PRINCE2's training material addresses these failures, blaming them on inappropriate tailoring of PRINCE2 to the project environment, and advocating for more PRINCE2 training for government project managers to solve the problem.[_[citation needed](/wiki/Wikipedia:Citation_needed "Wikipedia:Citation needed")_]
+
+## Differences from PMP
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=14 "Edit section: Differences from PMP")]
+
+[Project Management Professional](/wiki/Project_Management_Professional "Project Management Professional") (PMP) from [Project Management Institute](/wiki/Project_Management_Institute "Project Management Institute") may be seen as a competitor of PRINCE2. In general, the UK and Australia prefer PRINCE2, and US prefers PMP. Asia, Africa and the Middle East area have no strong preference for PMP or PRINCE2. The important thing is that PMP (PMBOK) can be used with PRINCE2.
+
+PRINCE2 and PMP acknowledge each other's existence in their advertising material and attempt to position themselves as complementary products – PRINCE2 as a "methodology" and PMP as a "standard"[20] – which can be used alongside each other. In practice, companies and practitioners choose one system or both depending on the project environment, their geographical location and costs involved.
+
+## See also
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=15 "Edit section: See also")]
+
+  * [Agile software development](/wiki/Agile_software_development "Agile software development")
+  * [Comparison of project-management software](/wiki/Comparison_of_project-management_software "Comparison of project-management software")
+  * [Gantt chart](/wiki/Gantt_chart "Gantt chart")
+  * [List of project management topics](/wiki/List_of_project_management_topics "List of project management topics")
+  * [Work breakdown structure](/wiki/Work_breakdown_structure "Work breakdown structure")
+
+## References
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=16 "Edit section: References")]
+
+  1. **^** ["What is PRINCE2®?"](https://www.axelos.com/best-practice-solutions/prince2/what-is-prince2). AXELOS. Retrieved 1 February 2017.
+  2. **^** ["PRINCE2 Consulting Organisations List"](https://web.archive.org/web/20071103173634/http://www.prince-officialsite.com/ConsultingOrganisations/ConsultingOrganisationsList.asp). Archived from [the original](http://www.prince-officialsite.com/ConsultingOrganisations/ConsultingOrganisationsList.asp) on 3 November 2007. Retrieved 20 December 2010.
+  3. **^** David Hinde (2012). [_PRINCE2 Study Guide_](https://books.google.com/books?id=lVVf-qoDZiUC&pg=PT16). John Wiley & Sons. p. 16. [ISBN](/wiki/ISBN_\(identifier\) "ISBN \(identifier\)") [978-1-119-97097-2](/wiki/Special:BookSources/978-1-119-97097-2 "Special:BookSources/978-1-119-97097-2").
+  4. **^** Reid, Amy (30 July 2013). ["Capita acquires majority stake in ITIL and PRINCE2"](https://web.archive.org/web/20160130015056/https://www.apm.org.uk/news/capita-acquires-majority-stake-itil-and-prince2). _Association for project management_. International project management association. Archived from [the original](https://www.apm.org.uk/news/capita-acquires-majority-stake-itil-and-prince2) on 30 January 2016. Retrieved 22 February 2016. "AXELOS has been revealed as the name of the new joint venture between Capita and the Cabinet Office set up to manage the best management practice training tools and accreditations, including PRINCE2, and ITIL. [...] Capita and the Cabinet Office have established a 51:49 per cent stake in the new organisation that will own the intellectual property (IP) of this portfolio of products [...]"
+  5. **^** _www.peoplecert.org_ <https://www.peoplecert.org/news-and-announcements/peoplecert-completes-axelos-acquisition>. Retrieved 11 July 2024. `{{[cite web](/wiki/Template:Cite_web "Template:Cite web")}}`: Missing or empty `|title=` ([help](/wiki/Help:CS1_errors#citation_missing_title "Help:CS1 errors"))
+  6. **^** ["PRINCE2 Methodology Overview: History, Definition & Meaning, Benefits, Certification"](https://mymanagementguide.com/prince2-methodology-overview-history-definition-meaning-benefits-certification/). 10 August 2011.
+  7. **^** Lewinson, Mary (10 August 2011). ["PRINCE2 Methodology Overview: History, Definition & Meaning, Benefits, Certification"](https://mymanagementguide.com/prince2-methodology-overview-history-definition-meaning-benefits-certification/). Retrieved 14 August 2019.
+  8. **^** ["How Many PRINCE2 Certified In The World? | PRINCE2 Worldwide Popularity | Infographic | Knowledge Train"](https://www.knowledgetrain.co.uk/project-management/prince2/prince2-course/prince2-popularity-grows). _www.knowledgetrain.co.uk_. 19 May 2023. Retrieved 13 July 2024.
+  9. **^** ["Introducing the PRINCE2 2017 Update"](https://www.axelos.com/prince2-2017) (Press release). Axelos. 11 December 2017.
+  10. ^ _**a**_ _**b**_ ["Managing Successful Projects with PRINCE2, 2017 Edition"](https://www.axelos.com/store/book/managing-successful-projects-with-prince2-2017). _Axelos_.
+  11. **^** PRINCE2 manual
+  12. **^** ["PRINCE2 Agile®"](https://web.archive.org/web/20150315054000/https://www.axelos.com/best-practice-solutions/prince2/prince2-agile). _www.axelos.com_. Axelos. Archived from [the original](https://www.axelos.com/best-practice-solutions/prince2/prince2-agile) on 15 March 2015. Retrieved 6 March 2015.
+  13. **^** ["PRINCE2 2017 is renamed PRINCE2 6th Edition | UK"](https://www.prince2.com/uk/blog/prince2-2017-is-renamed-prince2-6th-edition). _www.prince2.com_. Retrieved 24 June 2021.
+  14. **^** ["OGC Best Management Practice – PRINCE2"](https://web.archive.org/web/20081225083835/http://www.best-management-practice.com/Knowledge-Centre/Best-Practice-Guidance/PRINCE2/). Archived from [the original](http://www.best-management-practice.com/Knowledge-Centre/Best-Practice-Guidance/PRINCE2/) on 25 December 2008. Retrieved 22 April 2009.
+  15. **^** ["The Blair IT projects"](https://www.zdnet.com/home-and-office/networking/the-blair-it-projects/). _ZDNet.com_.
+  16. **^** King, Anthony; Crewe, Ivor (2013). _The Blunders of our Governments_. Oneworld Publications. [ISBN](/wiki/ISBN_\(identifier\) "ISBN \(identifier\)") [978-1780742663](/wiki/Special:BookSources/978-1780742663 "Special:BookSources/978-1780742663").
+  17. **^** ["The costly trail of British government IT and 'big bang' project disasters"](https://www.theguardian.com/technology/2014/aug/19/costly-trail-british-government-it-disasters-universal-credit). _theguardian.com_. 19 August 2014.
+  18. **^** ["Blair avoids MPs' questions on Capita"](https://www.telegraph.co.uk/finance/2935817/Blair-avoids-MPs-questions-on-Capita.html). _Telegraph.co.uk_. 2 April 2006.
+  19. **^** ["Capita chairman quits after criticism of loans to Labour"](https://www.theguardian.com/politics/2006/mar/24/uk.partyfunding). _theguardian.com_. 24 March 2006.
+  20. **^** ["Project Management Professional (PMP) ® Handbook"](https://web.archive.org/web/20111122042800/http://www.pmi.org/Certification/~/media/PDF/Certifications/pdc_pmphandbook.ashx). [Project Management Institute](/wiki/Project_Management_Institute "Project Management Institute"). Archived from [the original](http://www.pmi.org/certification/~/media/pdf/certifications/pdc_pmphandbook.ashx) on 22 November 2011. Retrieved 18 September 2009.
+
+## External links
+
+[[edit](/w/index.php?title=PRINCE2&action=edit&section=17 "Edit section: External links")]
+
+[![](//upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/40px-Commons-logo.svg.png)](/wiki/File:Commons-logo.svg)
+
+Wikimedia Commons has media related to [PRINCE2](https://commons.wikimedia.org/wiki/Category:PRINCE2 "commons:Category:PRINCE2").
+
+  * [Official website](https://peoplecert.org/browse-certifications/project-programme-and-portfolio-management)
+  * [Guidelines for Managing Projects (fully consistent with PRINCE2)](http://webarchive.nationalarchives.gov.uk/20090609003228/http://www.berr.gov.uk/files/file40647.pdf) from the UK Department for Business, Enterprise and Regulatory Reform (BERR)
+  * [PRINCE2.wiki](https://prince2.wiki/)
+
+[Authority control databases](/wiki/Help:Authority_control "Help:Authority control"): National [![Edit this at Wikidata](//upload.wikimedia.org/wikipedia/en/thumb/8/8a/OOjs_UI_icon_edit-ltr-progressive.svg/20px-OOjs_UI_icon_edit-ltr-progressive.svg.png)](https://www.wikidata.org/wiki/Q1140865#identifiers "Edit this at Wikidata")|
+
+  * [United States](https://id.loc.gov/authorities/sh2015002494)
+  * [Czech Republic](https://aleph.nkp.cz/F/?func=find-c&local_base=aut&ccl_term=ica=ph593765&CON_LNG=ENG)
+  * [Israel](https://www.nli.org.il/en/authorities/987007415881105171)
+
+---|---
+
+![](https://en.wikipedia.org/wiki/Special:CentralAutoLogin/start?useformat=desktop&type=1x1&usesul3=1)
+
+Retrieved from "[https://en.wikipedia.org/w/index.php?title=PRINCE2&oldid=1337828616](https://en.wikipedia.org/w/index.php?title=PRINCE2&oldid=1337828616)"

--- a/specifications/RUP/rup.md
+++ b/specifications/RUP/rup.md
@@ -1,0 +1,467 @@
+(Redirected from [Rational Unified Process](/w/index.php?title=Rational_Unified_Process&redirect=no "Rational Unified Process"))
+
+Part of a series on
+---
+[Software development](/wiki/Software_development "Software development")
+Core activities
+
+  * [Data modeling](/wiki/Data_modeling "Data modeling")
+  * [Processes](/wiki/Software_development_process "Software development process")
+  * [Requirements](/wiki/Requirements_analysis "Requirements analysis")
+  * [Design](/wiki/Software_design "Software design")
+  * [Construction](/wiki/Software_construction "Software construction")
+  * [Engineering](/wiki/Software_engineering "Software engineering")
+  * [Testing](/wiki/Software_testing "Software testing")
+  * [Debugging](/wiki/Debugging "Debugging")
+  * [Deployment](/wiki/Software_deployment "Software deployment")
+  * [Maintenance](/wiki/Software_maintenance "Software maintenance")
+
+Paradigms and models
+
+  * [Agile](/wiki/Agile_software_development "Agile software development")
+  * [Cleanroom](/wiki/Cleanroom_software_engineering "Cleanroom software engineering")
+  * [Incremental](/wiki/Incremental_build_model "Incremental build model")
+  * [Prototyping](/wiki/Software_prototyping "Software prototyping")
+  * [Spiral](/wiki/Spiral_model "Spiral model")
+  * [V model](/wiki/V-model_\(software_development\) "V-model \(software development\)")
+  * [Waterfall](/wiki/Waterfall_model "Waterfall model")
+
+[Methodologies](/wiki/Software_development_methodology "Software development methodology") and frameworks
+
+  * [ASD](/wiki/Adaptive_software_development "Adaptive software development")
+  * [DAD](/wiki/Disciplined_agile_delivery "Disciplined agile delivery")
+  * [DevOps](/wiki/DevOps "DevOps")
+  * [DSDM](/wiki/Dynamic_systems_development_method "Dynamic systems development method")
+  * [FDD](/wiki/Feature-driven_development "Feature-driven development")
+  * [IID](/wiki/Iterative_and_incremental_development "Iterative and incremental development")
+  * [Kanban](/wiki/Kanban_\(development\) "Kanban \(development\)")
+  * [Lean SD](/wiki/Lean_software_development "Lean software development")
+  * [LeSS](/wiki/Scrum_\(software_development\)#Large-scale_Scrum "Scrum \(software development\)")
+  * [MDD](/wiki/Model-driven_development "Model-driven development")
+  * [MSF](/wiki/Microsoft_Solutions_Framework "Microsoft Solutions Framework")
+  * [PSP](/wiki/Personal_software_process "Personal software process")
+  * [RAD](/wiki/Rapid_application_development "Rapid application development")
+  * RUP
+  * [SAFe](/wiki/Scaled_agile_framework "Scaled agile framework")
+  * [Scrum](/wiki/Scrum_\(software_development\) "Scrum \(software development\)")
+  * [SEMAT](/wiki/SEMAT "SEMAT")
+  * [TDD](/wiki/Test-driven_development "Test-driven development")
+  * [TSP](/wiki/Team_software_process "Team software process")
+  * [UP](/wiki/Unified_process "Unified process")
+  * [XP](/wiki/Extreme_programming "Extreme programming")
+
+Supporting disciplines
+
+  * [Configuration management](/wiki/Software_configuration_management "Software configuration management")
+  * [Deployment management](/wiki/Deployment_management#Computer_science "Deployment management")
+  * [Documentation](/wiki/Software_documentation "Software documentation")
+  * [Project management](/wiki/Software_project_management "Software project management")
+  * [Quality assurance](/wiki/Software_quality_assurance "Software quality assurance")
+  * [User experience](/wiki/User_experience "User experience")
+
+Practices
+
+  * [ATDD](/wiki/Acceptance_test-driven_development "Acceptance test-driven development")
+  * [BDD](/wiki/Behavior-driven_development "Behavior-driven development")
+  * [CCO](/wiki/Extreme_programming_practices#Collective_code_ownership "Extreme programming practices")
+  * [CD](/wiki/Continuous_delivery "Continuous delivery")
+  * [CI](/wiki/Continuous_integration "Continuous integration")
+  * [DDD](/wiki/Domain-driven_design "Domain-driven design")
+  * [PP](/wiki/Pair_programming "Pair programming")
+  * [SBE](/wiki/Specification_by_example "Specification by example")
+  * [Stand-up](/wiki/Stand-up_meeting "Stand-up meeting")
+  * [TDD](/wiki/Test-driven_development "Test-driven development")
+
+[Tools](/wiki/Programming_tool "Programming tool")
+
+  * [Build automation](/wiki/Build_automation "Build automation")
+  * [Compiler](/wiki/Compiler "Compiler")
+  * [Debugger](/wiki/Debugger "Debugger")
+  * [GUI builder](/wiki/Graphical_user_interface_builder "Graphical user interface builder")
+  * [IDE](/wiki/Integrated_development_environment "Integrated development environment")
+  * [Infrastructure as code](/wiki/Infrastructure_as_code "Infrastructure as code")
+  * [Profiler](/wiki/Profiling_\(computer_programming\) "Profiling \(computer programming\)")
+  * [Release automation](/wiki/Application-release_automation "Application-release automation")
+  * [UML Modeling](/wiki/UML_tool "UML tool")
+
+Standards and bodies of knowledge
+
+  * [CMMI](/wiki/Capability_Maturity_Model_Integration "Capability Maturity Model Integration")
+  * [IEEE standards](/wiki/IEEE_Standards_Association "IEEE Standards Association")
+  * [IREB](/wiki/International_Requirements_Engineering_Board "International Requirements Engineering Board")
+  * [ISO 9001](/wiki/ISO_9001 "ISO 9001")
+  * [ISO/IEC standards](/wiki/ISO/IEC_JTC_1/SC_7 "ISO/IEC JTC 1/SC 7")
+  * [ITIL](/wiki/ITIL "ITIL")
+  * [OMG](/wiki/Object_Management_Group "Object Management Group")
+  * [PMBOK](/wiki/Project_Management_Body_of_Knowledge "Project Management Body of Knowledge")
+  * [SWEBOK](/wiki/Software_Engineering_Body_of_Knowledge "Software Engineering Body of Knowledge")
+
+Glossaries
+
+  * [Artificial intelligence](/wiki/Glossary_of_artificial_intelligence "Glossary of artificial intelligence")
+  * [Computer science](/wiki/Glossary_of_computer_science "Glossary of computer science")
+  * [Electrical and electronics engineering](/wiki/Glossary_of_electrical_and_electronics_engineering "Glossary of electrical and electronics engineering")
+
+Outlines
+
+  * [Software development](/wiki/Outline_of_software_development "Outline of software development")
+  * [C programming language](/wiki/Outline_of_the_C_programming_language "Outline of the C programming language")
+  * [C sharp programming language](/wiki/Outline_of_the_C_sharp_programming_language "Outline of the C sharp programming language")
+  * [C++ programming language](/wiki/Outline_of_the_C%2B%2B_programming_language "Outline of the C++ programming language")
+  * [Java programming language](/wiki/Outline_of_the_Java_programming_language "Outline of the Java programming language")
+  * [JavaScript programming language](/wiki/Outline_of_the_JavaScript_programming_language "Outline of the JavaScript programming language")
+  * [Python programming language](/wiki/Outline_of_the_Python_programming_language "Outline of the Python programming language")
+  * [Rust programming language](/wiki/Outline_of_the_Rust_programming_language "Outline of the Rust programming language")
+
+  * [v](/wiki/Template:Software_development_process "Template:Software development process")
+  * [t](/wiki/Template_talk:Software_development_process "Template talk:Software development process")
+  * [e](/wiki/Special:EditPage/Template:Software_development_process "Special:EditPage/Template:Software development process")
+
+The **Rational Unified Process** (**RUP**) is an [iterative](/wiki/Iterative_and_incremental_development "Iterative and incremental development") [software development process](/wiki/Software_development_process "Software development process") framework created by the [Rational Software](/wiki/Rational_Software "Rational Software") Corporation, a division of [IBM](/wiki/IBM "IBM") since 2003.[1] RUP is not a single concrete prescriptive process, but rather an adaptable process [framework](/wiki/Software_framework "Software framework"), intended to be tailored by the development organizations and software project teams that will select the elements of the process that are appropriate for their needs. RUP is a specific implementation of the [Unified Process](/wiki/Unified_Process "Unified Process").
+
+## History
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=1 "Edit section: History")]
+
+Rational Software originally developed the RUP as a software process product. The product includes a hyperlinked knowledge-base with sample [artifacts](/wiki/Artifact_\(software_development\) "Artifact \(software development\)") and detailed descriptions for many different types of activities. RUP is included in the Rational Method Composer (RMC) product which allows customization of the process.
+
+[Philippe Kruchten](/wiki/Philippe_Kruchten "Philippe Kruchten"), an experienced Rational technical representative was tasked with heading up the original RUP team.
+
+These initial versions combined the Rational Software organisation's extensive field experience building object-oriented systems (referred to by Rational field staff as the Rational Approach) with Objectory's guidance on practices such as use cases, and incorporated extensive content from Jim Rumbaugh's [Object Modeling Technology](/wiki/Object-modeling_technique "Object-modeling technique") (OMT) approach to modeling, Grady Booch's [Booch method](/wiki/Booch_method "Booch method"), and the newly released [UML](/wiki/Unified_Modeling_Language "Unified Modeling Language") 0.8.[2][3]
+
+To help make this growing knowledge base more accessible, [Philippe Kruchten](/wiki/Philippe_Kruchten "Philippe Kruchten") was tasked with the assembly of an explicit process framework for modern software engineering. This effort employed the [HTML](/wiki/HTML "HTML")-based process delivery mechanism developed by Objectory. The resulting "Rational Unified Process" (RUP) completed a strategic tripod for Rational:
+
+  * a _tailorable process_ that guided development
+  * _tools_ that automated the application of that process
+  * _services_ that accelerated adoption of both the process and the tools.
+
+This guidance was augmented in subsequent versions with knowledge based on the experience of companies that Rational had acquired.
+
+In 1997, a requirements and test discipline were added to the approach, much of the additional material sourced from the Requirements College method developed by Dean Leffingwell et al. at Requisite, Inc., and the SQA Process method developed at SQA Inc., both companies having been acquired by Rational Software.
+
+In 1998 Rational Software added two new disciplines:
+
+  1. business modeling, much of this content had already been in the Objectory Process
+  2. a Configuration and Change Management discipline, sourced through the acquisition of Pure Atria Corporation.
+
+These additions lead to an overarching set of principles that were defined by Rational and articulated within RUP as the six _best practices_ for modern software engineering:
+
+  1. Develop iteratively, with risk as the primary iteration driver[4]
+  2. Manage requirements
+  3. Employ a component-based architecture
+  4. Model software visually
+  5. Continuously verify quality
+  6. Control changes
+
+These best practices were tightly aligned with Rational's product line, and both drove the ongoing development of Rational's products, as well as being used by Rational's field teams to help customers improve the quality and predictability of their software development efforts.
+
+Additional techniques including performance testing, UI Design, data engineering were included, and an update to reflect changes in UML 1.1.
+
+In 1999, a project management discipline was introduced, as well as techniques to support real-time software development and updates to reflect UML 1.3. Besides, the first book to describe the process, _The Unified Software Development Process_ ([ISBN](/wiki/ISBN_\(identifier\) "ISBN \(identifier\)") [0-201-57169-2](/wiki/Special:BookSources/0-201-57169-2 "Special:BookSources/0-201-57169-2")) by [Ivar Jacobson](/wiki/Ivar_Jacobson "Ivar Jacobson"), [Grady Booch](/wiki/Grady_Booch "Grady Booch") and [James Rumbaugh](/wiki/James_Rumbaugh "James Rumbaugh")., was published in the same year.
+
+Between 2000 and 2003, a number of changes introduced guidance from ongoing Rational field experience with iterative development, in addition to tool support for enacting RUP instances and for customization of the RUP framework. These changes included:
+
+  1. the introduction of concepts and techniques from approaches such as eXtreme Programming (XP), that would later come to be known collectively as agile methods. This included techniques such as pair programming, test-first design, and papers that explained how RUP enabled XP to scale for use on larger projects.
+  2. a complete overhaul of the testing discipline to better reflect how testing work was conducted in different iterative development contexts.
+  3. the introduction of supporting guidance - known as "tool mentors" - for enacting the RUP practices in various tools. These essentially provided step-by-step method support to Rational tool users.
+  4. automating the customization of RUP in a way that would allow customers to select parts from the RUP process framework, customize their selection with their own additions, and still incorporate improvements in subsequent releases from Rational.
+
+IBM acquired Rational Software in February 2003.
+
+In 2006, IBM created a subset of RUP tailored for the delivery of [Agile](/wiki/Agile_software_development "Agile software development") projects - released as an OpenSource method called OpenUP through the [Eclipse](/wiki/Eclipse_\(software\) "Eclipse \(software\)") web-site.[5]
+
+## Rational unified process topics
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=2 "Edit section: Rational unified process topics")]
+
+### RUP building blocks
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=3 "Edit section: RUP building blocks")]
+
+RUP is based on a set of building blocks and content elements, describing what is to be produced, the necessary skills required and the step-by-step explanation describing how specific development goals are to be achieved. The main building blocks, or content elements, are the following:
+
+  * Roles (who) – A role defines a set of related skills, competencies and responsibilities.
+  * Work products (what) – A work product represents something resulting from a task, including all the documents and models produced while working through the process.
+  * Tasks (how) – A task describes a unit of work assigned to a Role that provides a meaningful result.
+
+Within each iteration, the tasks are categorized into nine disciplines:
+
+  * Six "engineering disciplines"
+    * Business modelling
+    * Requirements
+    * Analysis and design
+    * Implementation
+    * Test
+    * Deployment
+  * Three supporting disciplines
+    * [Configuration and change management](/wiki/Software_configuration_management "Software configuration management")
+    * [Project management](/wiki/Software_project_management "Software project management")
+    * [Environment](/wiki/Environment_discipline "Environment discipline")
+
+### Four project life-cycle phases
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=4 "Edit section: Four project life-cycle phases")]
+
+[![](//upload.wikimedia.org/wikipedia/commons/thumb/1/19/Development-iterative.png/330px-Development-iterative.png)](/wiki/File:Development-iterative.png)RUP phases and disciplines.
+
+The RUP has determined a project life-cycle consisting of four phases. These phases allow the process to be presented at a high level in a similar way to how a 'waterfall'-styled project might be presented, although in essence the key to the process lies in the iterations of development that lie within all of the phases. Also, each phase has one key objective and milestone at the end that denotes the objective being accomplished. The visualization of RUP phases and disciplines over time is referred to as the [RUP hump](/wiki/RUP_hump "RUP hump") chart.
+
+#### Inception phase
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=5 "Edit section: Inception phase")]
+
+The primary objective is to scope the system adequately as a basis for validating initial costing and budgets. In this phase the business case which includes business context, success factors (expected revenue, market recognition, etc.), and financial forecast is established. To complement the business case, a basic use case model, project plan, initial risk assessment and project description (the core project requirements, constraints and key features) are generated. After these are completed, the project is checked against the following criteria:
+
+  * [Stakeholder](/wiki/Stakeholder_\(corporate\)#In_management "Stakeholder \(corporate\)") concurrence on scope definition and cost/schedule estimates.
+  * Requirements understanding as evidenced by the fidelity of the primary use cases.
+  * Credibility of the cost/schedule estimates, priorities, risks, and development process.
+  * Depth and breadth of any architectural prototype that was developed.
+  * Establishing a baseline by which to compare actual expenditures versus planned expenditures.
+
+If the project does not pass this milestone, called the life cycle objective milestone, it either can be cancelled or repeated after being redesigned to better meet the criteria.
+
+#### Elaboration phase
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=6 "Edit section: Elaboration phase")]
+
+The primary objective is to mitigate the key risk items identified by analysis up to the end of this phase. The elaboration phase is where the project starts to take shape. In this phase the problem domain analysis is made and the architecture of the project gets its basic form.
+
+The outcome of the elaboration phase is:
+
+  * A use-case model in which the use-cases and the actors have been identified and most of the use-case descriptions are developed. The use-case model should be 80% complete.
+  * A description of the software architecture in a software system development process.
+  * An [executable architecture](/wiki/Executable_Architecture "Executable Architecture") that realizes architecturally significant use cases.
+  * Business case and risk list which are revised.
+  * A development plan for the overall project.
+  * Prototypes that demonstrably mitigate each identified technical risk.
+  * A preliminary user manual (optional)
+
+This phase must pass the lifecycle architecture milestone criteria answering the following questions:
+
+  * Is the vision of the product stable?
+  * Is the architecture stable?
+  * Does the executable demonstration indicate that major risk elements are addressed and resolved?
+  * Is the construction phase plan sufficiently detailed and accurate?
+  * Do all stakeholders agree that the current vision can be achieved using current plan in the context of the current architecture?
+  * Is the actual vs. planned resource expenditure acceptable?
+
+If the project cannot pass this milestone, there is still time for it to be canceled or redesigned. However, after leaving this phase, the project transitions into a high-risk operation where changes are much more difficult and detrimental when made.
+
+The key domain analysis for the elaboration is the system architecture.
+
+#### Construction phase
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=7 "Edit section: Construction phase")]
+
+The primary objective is to build the software system. In this phase, the main focus is on the development of components and other features of the system. This is the phase when the bulk of the coding takes place. In larger projects, several construction iterations may be developed in an effort to divide the use cases into manageable segments to produce demonstrable prototypes.
+
+#### Transition phase
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=8 "Edit section: Transition phase")]
+
+The primary objective is to 'transit' the system from development into production, making it available to and understood by the end user. The activities of this phase include training the end users and maintainers and beta testing the system to validate it against the end users' expectations. The system also goes through an evaluation phase, any developer which is not producing the required work is replaced or removed. The product is also checked against the quality level set in the Inception phase.
+
+If all objectives are met, the product release milestone is reached and the development cycle is finished.
+
+### The IBM Rational Method Composer product
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=9 "Edit section: The IBM Rational Method Composer product")]
+
+The IBM Rational Method Composer product is a tool for authoring, configuring, viewing, and publishing processes. See [IBM Rational Method Composer](/w/index.php?title=IBM_Rational_Method_Composer&action=edit&redlink=1 "IBM Rational Method Composer \(page does not exist\)") and an open source version [Eclipse process framework](/wiki/Eclipse_process_framework "Eclipse process framework") (EPF) project for more details.
+
+### Certification
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=10 "Edit section: Certification")]
+
+In January 2007 the new RUP certification examination for _IBM Certified Solution Designer - Rational Unified Process 7.0_ was released which replaces the previous version of the course called _IBM Rational Certified Specialist - Rational Unified Process_.[6] The new examination will not only test knowledge related to the RUP content but also to the process structure elements.[7]
+
+To pass the new RUP certification examination, a person must take IBM's _Test 839: Rational Unified Process v7.0_. You are given 75 minutes to take the 52 question exam. The passing score is 62%.[8]
+
+### Six best practices
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=11 "Edit section: Six best practices")]
+
+Six best [software engineering](/wiki/Software_engineering "Software engineering") practices are defined for software projects to minimize faults and increase productivity. These are:[9][10]
+
+Develop iteratively
+    It is best to know all requirements in advance; however, often this is not the case. Several software development processes exist that deal with providing solutions to minimize cost in terms of development phases.
+Manage requirements
+    Always keep in mind the requirements set by users.
+Use components
+    Breaking down an advanced project is not only suggested but in fact unavoidable. This promotes ability to test individual components before they are integrated into a larger system. Also, code reuse is a big plus and can be accomplished more easily through the use of [object-oriented programming](/wiki/Object-oriented_programming "Object-oriented programming").
+Model visually
+    Use diagrams to represent all major components, users, and their interaction. "UML", short for [Unified Modeling Language](/wiki/Unified_Modeling_Language "Unified Modeling Language"), is one tool that can be used to make this task more feasible.
+Verify quality
+    Always make testing a major part of the project at any point of time. Testing becomes heavier as the project progresses but should be a constant factor in any software product creation.
+Control changes
+    Many projects are created by many teams, sometimes in various locations, different platforms may be used, etc. As a result, it is essential to make sure that changes made to a system are synchronized and verified constantly. (See [Continuous integration](/wiki/Continuous_integration "Continuous integration")).
+
+## See also
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=12 "Edit section: See also")]
+
+  * [Agile modeling](/wiki/Agile_modeling "Agile modeling")
+  * [Agile unified process](/wiki/Agile_unified_process "Agile unified process")
+  * [Disciplined agile delivery](/wiki/Disciplined_agile_delivery "Disciplined agile delivery")
+  * [Dynamic systems development method](/wiki/Dynamic_systems_development_method "Dynamic systems development method")
+  * [Computer programming](/wiki/Computer_programming "Computer programming")
+  * [Feature-driven development](/wiki/Feature-driven_development "Feature-driven development")
+  * [Macroscope (methodology suite)](/wiki/Macroscope_\(methodology_suite\) "Macroscope \(methodology suite\)")
+  * [Project life cycle](/wiki/Project_life_cycle "Project life cycle")
+  * [Quality assurance](/wiki/Quality_assurance "Quality assurance")
+  * [Quality control](/wiki/Quality_control "Quality control")
+  * [Scaled agile framework](/wiki/Scaled_agile_framework "Scaled agile framework")
+  * [Software architecture](/wiki/Software_architecture "Software architecture")
+  * [Software component](/wiki/Software_component "Software component")
+  * [Software development process](/wiki/Software_development_process "Software development process")
+  * [Software engineering](/wiki/Software_engineering "Software engineering")
+  * [Software testing](/wiki/Software_testing "Software testing")
+  * [Test-driven development](/wiki/Test-driven_development "Test-driven development")
+  * [Unified Process for Education](/wiki/UPEDU "UPEDU")
+
+## References
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=13 "Edit section: References")]
+
+  1. **^** [IBM Acquires Rational](http://www.eweek.com/c/a/Desktops-and-Notebooks/IBM-Acquires-Rational/)
+  2. **^** Jacobson, Sten (2002-07-19). ["The Rational Objectory Process - A UML-based Software Engineering Process"](https://web.archive.org/web/20190527224552/http://www.iscn.at/select_newspaper/object/rational.html). [Rational Software Scandinavia AB](/w/index.php?title=Rational_Software_Scandinavia_AB&action=edit&redlink=1 "Rational Software Scandinavia AB \(page does not exist\)"). Archived from [the original](http://www.iscn.at/select_newspaper/object/rational.html) on 2019-05-27. Retrieved 2014-12-17.
+  3. **^** Kruchten, Philippe (2004-05-01). [_The Rational Unified Process: An Introduction_](https://books.google.com/books?id=RYCMx6o47pMC&pg=PA33). [Addison-Wesley](/wiki/Addison-Wesley "Addison-Wesley"). p. 33. [ISBN](/wiki/ISBN_\(identifier\) "ISBN \(identifier\)") [9780321197702](/wiki/Special:BookSources/9780321197702 "Special:BookSources/9780321197702"). Retrieved 2014-12-17.
+  4. **^** Aked, Mark (2003-11-25). ["RUP in brief"](http://www.ibm.com/developerworks/rational/library/1826.html#N100E4). [IBM](/wiki/IBM "IBM"). Retrieved 2011-07-12.
+  5. **^** ["OpenUP"](https://web.archive.org/web/20140106040945/http://epf.eclipse.org/wikis/openup/). Archived from [the original](http://epf.eclipse.org/wikis/openup/) on 2014-01-06. Retrieved 2013-08-03.
+  6. **^** Krebs, Jochen (2007-01-15). ["The value of RUP certification"](http://www.ibm.com/developerworks/rational/library/jan07/krebs/). [IBM](/wiki/IBM "IBM"). Retrieved 2014-05-05.
+  7. **^** ["Spacer IBM Certified Solution Designer - IBM Rational Unified Process V7.0"](https://web.archive.org/web/20070108125343/http://www-03.ibm.com/certify/certs/38008003.shtml). [IBM](/wiki/IBM "IBM"). Archived from [the original](http://www-03.ibm.com/certify/certs/38008003.shtml) on January 8, 2007. Retrieved 2008-05-13.
+  8. **^** ["Test 839: Rational Unified Process v7.0"](http://www-03.bm.com/certify/tests/ovr839.shtml). [IBM](/wiki/IBM "IBM"). Retrieved 2008-05-13.[_[permanent dead link](/wiki/Wikipedia:Link_rot "Wikipedia:Link rot")_]
+  9. **^** Stephen Schach (2004). _Classical and Object-Oriented Software Engineering_. 6/e, WCB McGraw Hill, New York, 2004.
+  10. **^** [Rational Unified Process white paper](http://www.augustana.ab.ca/~mohrj/courses/2000.winter/csc220/papers/rup_best_practices/rup_bestpractices.html) [Archived](https://web.archive.org/web/20090501034302/http://www.augustana.ab.ca/~mohrj/courses/2000.winter/csc220/papers/rup_best_practices/rup_bestpractices.html) 2009-05-01 at the [Wayback Machine](/wiki/Wayback_Machine "Wayback Machine")
+
+## Further reading
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=14 "Edit section: Further reading")]
+
+  * [Ivar Jacobson](/wiki/Ivar_Jacobson "Ivar Jacobson"), [Grady Booch](/wiki/Grady_Booch "Grady Booch"), and [James Rumbaugh](/wiki/James_Rumbaugh "James Rumbaugh") (1999). _The Unified Software Development Process_
+  * Gary Pollice, Liz Augustine, Chris Lowe, and Jas Madhur (2003). _Software Development for Small Teams: A RUP-Centric Approach_
+  * Per Kroll, [Philippe Kruchten](/wiki/Philippe_Kruchten "Philippe Kruchten") (2003). _Rational Unified Process Made Easy, The: A Practitioner's Guide to the RUP_
+  * Per Kroll, Bruce Mac Isaac (2006). _Agility and Discipline Made Easy: Practices from OpenUP and RUP_
+  * [Philippe Kruchten](/wiki/Philippe_Kruchten "Philippe Kruchten") (1998). _The Rational Unified Process: An Introduction_
+  * Ahmad Shuja, Jochen Krebs (2007). _RUP Reference and Certification Guide_
+  * Walker Royce, _Software Project Management, A Unified Framework_
+  * Paul Szymkowiak, [Philippe Kruchten](/wiki/Philippe_Kruchten "Philippe Kruchten") (2003). _Testing: The RUP Philosophy_ [1]
+
+## External links
+
+[[edit](/w/index.php?title=Rational_unified_process&action=edit&section=15 "Edit section: External links")]
+
+  * [IBM Rational Unified Process Web Site](https://web.archive.org/web/20040402113344/http://www-306.ibm.com/software/awdtools/rup/)
+
+  * [v](/wiki/Template:Unified_Modeling_Language "Template:Unified Modeling Language")
+  * [t](/wiki/Template_talk:Unified_Modeling_Language "Template talk:Unified Modeling Language")
+  * [e](/wiki/Special:EditPage/Template:Unified_Modeling_Language "Special:EditPage/Template:Unified Modeling Language")
+
+[Unified Modeling Language](/wiki/Unified_Modeling_Language "Unified Modeling Language")
+---
+Actors|
+
+  * _Organizations_
+    * [Object Management Group](/wiki/Object_Management_Group "Object Management Group")
+    * [UML Partners](/wiki/UML_Partners "UML Partners")
+  * _Persons_
+    * [Grady Booch](/wiki/Grady_Booch "Grady Booch")
+    * [Ivar Jacobson](/wiki/Ivar_Jacobson "Ivar Jacobson")
+    * [James Rumbaugh](/wiki/James_Rumbaugh "James Rumbaugh")
+
+| [![](//upload.wikimedia.org/wikipedia/commons/thumb/1/1d/Use_case_restaurant_model.svg/120px-Use_case_restaurant_model.svg.png)](/wiki/Use_case_diagram "Use case diagram")
+Concepts| | Object oriented|
+
+  * [Object-oriented programming](/wiki/Object-oriented_programming "Object-oriented programming")
+  * [Object-oriented analysis and design](/wiki/Object-oriented_analysis_and_design "Object-oriented analysis and design")
+  * [Object-oriented modeling](/wiki/Object-oriented_modeling "Object-oriented modeling")
+
+---|---
+Structure|
+
+  * [Actor](/wiki/Actor_\(UML\) "Actor \(UML\)")
+  * [Attribute](/wiki/Attribute_\(computing\) "Attribute \(computing\)")
+  * [Artifact](/wiki/Artifact_\(UML\) "Artifact \(UML\)")
+  * [Class](/wiki/Class_\(programming\) "Class \(programming\)")
+  * [Component](/wiki/Component_\(UML\) "Component \(UML\)")
+  * [Interface](/wiki/Protocol_\(object-oriented_programming\) "Protocol \(object-oriented programming\)")
+  * [Object](/wiki/Object_\(computer_science\) "Object \(computer science\)")
+  * [Package](/wiki/Package_\(UML\) "Package \(UML\)")
+  * [Profile diagram](/wiki/Profile_diagram "Profile diagram")
+
+Behavior|
+
+  * [Activity](/wiki/Activity_\(UML\) "Activity \(UML\)")
+  * [Event](/wiki/Event_\(UML\) "Event \(UML\)")
+  * [Message](/wiki/Message_passing "Message passing")
+  * [Method](/wiki/Method_\(computer_programming\) "Method \(computer programming\)")
+  * [State](/wiki/State_\(computer_science\) "State \(computer science\)")
+  * [Use case](/wiki/Use_case "Use case")
+
+Relationships|
+
+  * [Association](/wiki/Association_\(object-oriented_programming\) "Association \(object-oriented programming\)")
+  * [Composition](/wiki/Object_composition "Object composition")
+  * [Dependency](/wiki/Coupling_\(computer_programming\) "Coupling \(computer programming\)")
+  * [Generalization](/wiki/Generalization "Generalization") (or [Inheritance](/wiki/Inheritance_\(object-oriented_programming\) "Inheritance \(object-oriented programming\)"))
+
+Extensibility|
+
+  * [Profile](/wiki/Profile_\(UML\) "Profile \(UML\)")
+  * [Stereotype](/wiki/Stereotype_\(UML\) "Stereotype \(UML\)")
+
+Other|
+
+  * [Multiplicity](/wiki/Class_diagram#Multiplicity "Class diagram")
+
+Diagrams| | Structure|
+
+  * [Class](/wiki/Class_diagram "Class diagram")
+  * [Component](/wiki/Component_diagram "Component diagram")
+  * [Composite structure](/wiki/Composite_structure_diagram "Composite structure diagram")
+  * [Deployment](/wiki/Deployment_diagram "Deployment diagram")
+  * [Object](/wiki/Object_diagram "Object diagram")
+  * [Package](/wiki/Package_diagram "Package diagram")
+
+---|---
+Behaviour|
+
+  * [Activity](/wiki/Activity_diagram "Activity diagram")
+  * [State Machine](/wiki/UML_state_machine "UML state machine")
+  * [Use case](/wiki/Use_case_diagram "Use case diagram")
+
+Interaction|
+
+  * [Communications](/wiki/Communication_diagram "Communication diagram")
+  * [Sequence](/wiki/Sequence_diagram "Sequence diagram")
+  * [Interaction overview](/wiki/Interaction_overview_diagram "Interaction overview diagram")
+  * [Timing](/wiki/Timing_diagram_\(Unified_Modeling_Language\) "Timing diagram \(Unified Modeling Language\)")
+
+Derived languages|
+
+  * [Systems Modeling Language (SysML)](/wiki/Systems_Modeling_Language "Systems Modeling Language")
+  * [UML eXchange Format (UXF)](/wiki/UXF "UXF")
+  * [XML Metadata Interchange (XMI)](/wiki/XML_Metadata_Interchange "XML Metadata Interchange")
+  * [Executable UML (xUML)](/wiki/Executable_UML "Executable UML")
+
+Other topics|
+
+  * [Glossary of UML terms](/wiki/Glossary_of_Unified_Modeling_Language_terms "Glossary of Unified Modeling Language terms")
+  * [Rational Unified Process](/wiki/Rational_Unified_Process "Rational Unified Process")
+  * [List of Unified Modeling Language tools](/wiki/List_of_Unified_Modeling_Language_tools "List of Unified Modeling Language tools")
+  * [Object Modeling in Color](/wiki/Object_Modeling_in_Color "Object Modeling in Color")
+
+[Authority control databases](/wiki/Help:Authority_control "Help:Authority control") [![Edit this at Wikidata](//upload.wikimedia.org/wikipedia/en/thumb/8/8a/OOjs_UI_icon_edit-ltr-progressive.svg/20px-OOjs_UI_icon_edit-ltr-progressive.svg.png)](https://www.wikidata.org/wiki/Q478019#identifiers "Edit this at Wikidata")|
+
+  * [GND](https://d-nb.info/gnd/4560513-0)
+
+---|---
+
+  1. **^** Szymkowiak, Paul; Kruchten, Philippe (February 2003). ["Testing: The RUP Philosophy"](https://www.academia.edu/75941761). _Academia.Edu_. Rational Software (Rational Edge e-zine). p. 11. Retrieved 2022-10-13.
+
+![](https://en.wikipedia.org/wiki/Special:CentralAutoLogin/start?useformat=desktop&type=1x1&usesul3=1)
+
+Retrieved from "[https://en.wikipedia.org/w/index.php?title=Rational_unified_process&oldid=1303088770](https://en.wikipedia.org/w/index.php?title=Rational_unified_process&oldid=1303088770)"
+  *[v]: View this template
+  *[t]: Discuss this template
+  *[e]: Edit this template

--- a/specifications/SCRUM/scrum.md
+++ b/specifications/SCRUM/scrum.md
@@ -1,0 +1,707 @@
+Ken Schwaber & Jeff Sutherland
+
+The Scrum Guide
+
+The Definitive Guide to Scrum: The Rules of the Game
+
+November 2020
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Purpose of the Scrum Guide
+We developed Scrum in the early 1990s. We wrote the first version of the Scrum Guide in 2010 to help
+people worldwide understand Scrum.  We have evolved the Guide since then through small, functional
+updates. Together, we stand behind it.
+
+The Scrum Guide contains the definition of Scrum. Each element of the framework serves a specific
+purpose that is essential to the overall value and results realized with Scrum. Changing the core design
+or ideas of Scrum, leaving out elements, or not following the rules of Scrum, covers up problems and
+limits the benefits of Scrum, potentially even rendering it useless.
+
+We follow the growing use of Scrum within an ever-growing complex world. We are humbled to see
+Scrum being adopted in many domains holding essentially complex work, beyond software product
+development where Scrum has its roots. As Scrum’s use spreads, developers, researchers, analysts,
+scientists, and other specialists do the work. We use the word “developers” in Scrum not to exclude,
+but to simplify. If you get value from Scrum, consider yourself included.
+
+As Scrum is being used, patterns, processes, and insights that fit the Scrum framework as described in
+this document, may be found, applied and devised. Their description is beyond the purpose of the
+Scrum Guide because they are context sensitive and differ widely between Scrum uses. Such tactics for
+using within the Scrum framework vary widely and are described elsewhere.
+
+Ken Schwaber & Jeff Sutherland November 2020
+
+© 2020 Ken Schwaber and Jeff Sutherland
+
+This publication is offered for license under the Attribution Share-Alike license of Creative Commons,
+accessible at https://creativecommons.org/licenses/by-sa/4.0/legalcode and also described in summary
+form at https://creativecommons.org/licenses/by-sa/4.0/. By utilizing this Scrum Guide, you
+acknowledge and agree that you have read and agree to be bound by the terms of the Attribution
+Share-Alike license of Creative Commons.
+
+1
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Purpose of the Scrum Guide .......................................................................................................................... 1
+
+Scrum Definition ............................................................................................................................................ 3
+
+Scrum Theory ................................................................................................................................................. 3
+
+Transparency ............................................................................................................................................. 3
+
+Inspection .................................................................................................................................................. 4
+
+Adaptation ................................................................................................................................................. 4
+
+Scrum Values ................................................................................................................................................. 4
+
+Scrum Team ................................................................................................................................................... 5
+
+Developers ................................................................................................................................................. 5
+
+Product Owner ........................................................................................................................................... 5
+
+Scrum Master ............................................................................................................................................. 6
+
+Scrum Events ................................................................................................................................................. 7
+
+The Sprint ................................................................................................................................................... 7
+
+Sprint Planning ........................................................................................................................................... 8
+
+Daily Scrum ................................................................................................................................................ 9
+
+Sprint Review ............................................................................................................................................. 9
+
+Sprint Retrospective ................................................................................................................................ 10
+
+Scrum Artifacts............................................................................................................................................. 10
+
+Product Backlog ....................................................................................................................................... 10
+
+Commitment: Product Goal ................................................................................................................. 11
+
+Sprint Backlog .......................................................................................................................................... 11
+
+Commitment: Sprint Goal .................................................................................................................... 11
+
+Increment................................................................................................................................................. 11
+
+Commitment: Definition of Done ........................................................................................................ 12
+
+End Note ...................................................................................................................................................... 13
+
+Acknowledgements ................................................................................................................................. 13
+
+People .................................................................................................................................................. 13
+
+Scrum Guide History ............................................................................................................................ 13
+
+2
+
+
+
+
+
+
+Scrum Definition
+Scrum is a lightweight framework that helps people, teams and organizations generate value through
+adaptive solutions for complex problems.
+
+In a nutshell, Scrum requires a Scrum Master to foster an environment where:
+
+1.  A Product Owner orders the work for a complex problem into a Product Backlog.
+2.  The Scrum Team turns a selection of the work into an Increment of value during a Sprint.
+3.  The Scrum Team and its stakeholders inspect the results and adjust for the next Sprint.
+4.  Repeat
+
+Scrum is simple. Try it as is and determine if its philosophy, theory, and structure help to achieve goals
+and create value. The Scrum framework is purposefully incomplete, only defining the parts required to
+implement Scrum theory. Scrum is built upon by the collective intelligence of the people using it. Rather
+than provide people with detailed instructions, the rules of Scrum guide their relationships and
+interactions.
+
+Various processes, techniques and methods can be employed within the framework. Scrum wraps
+around existing practices or renders them unnecessary. Scrum makes visible the relative efficacy of
+current management, environment, and work techniques, so that improvements can be made.
+
+Scrum Theory
+Scrum is founded on empiricism and lean thinking. Empiricism asserts that knowledge comes from
+experience and making decisions based on what is observed. Lean thinking reduces waste and focuses
+on the essentials.
+
+Scrum employs an iterative, incremental approach to optimize predictability and to control risk. Scrum
+engages groups of people who collectively have all the skills and expertise to do the work and share or
+acquire such skills as needed.
+
+Scrum combines four formal events for inspection and adaptation within a containing event, the Sprint.
+These events work because they implement the empirical Scrum pillars of transparency, inspection, and
+adaptation.
+
+Transparency
+
+The emergent process and work must be visible to those performing the work as well as those receiving
+
+the work. With Scrum, important decisions are based on the perceived state of its three formal artifacts.
+
+Artifacts that have low transparency can lead to decisions that diminish value and increase risk.
+
+3
+
+
+
+
+
+
+
+
+Transparency enables inspection. Inspection without transparency is misleading and wasteful.
+
+Inspection
+
+The Scrum artifacts and the progress toward agreed goals must be inspected frequently and diligently to
+detect potentially undesirable variances or problems. To help with inspection, Scrum provides cadence
+in the form of its five events.
+
+Inspection enables adaptation. Inspection without adaptation is considered pointless. Scrum events are
+designed to provoke change.
+
+Adaptation
+
+If any aspects of a process deviate outside acceptable limits or if the resulting product is unacceptable,
+the process being applied or the materials being produced must be adjusted. The adjustment must be
+made as soon as possible to minimize further deviation.
+
+Adaptation becomes more difficult when the people involved are not empowered or self-managing. A
+Scrum Team is expected to adapt the moment it learns anything new through inspection.
+
+Scrum Values
+Successful use of Scrum depends on people becoming more proficient in living five values:
+
+Commitment, Focus, Openness, Respect, and Courage
+
+The Scrum Team commits to achieving its goals and to supporting each other. Their primary focus is on
+the work of the Sprint to make the best possible progress toward these goals. The Scrum Team and its
+stakeholders are open about the work and the challenges. Scrum Team members respect each other to
+be capable, independent people, and are respected as such by the people with whom they work. The
+Scrum Team members have the courage to do the right thing, to work on tough problems.
+
+These values give direction to the Scrum Team with regard to their work, actions, and behavior. The
+decisions that are made, the steps taken, and the way Scrum is used should reinforce these values, not
+diminish or undermine them. The Scrum Team members learn and explore the values as they work with
+the Scrum events and artifacts. When these values are embodied by the Scrum Team and the people
+they work with, the empirical Scrum pillars of transparency, inspection, and adaptation come to life
+building trust.
+
+4
+
+
+
+
+
+
+Scrum Team
+The fundamental unit of Scrum is a small team of people, a Scrum Team. The Scrum Team consists of
+one Scrum Master, one Product Owner, and Developers. Within a Scrum Team, there are no sub-teams
+or hierarchies. It is a cohesive unit of professionals focused on one objective at a time, the Product Goal.
+
+Scrum Teams are cross-functional, meaning the members have all the skills necessary to create value
+each Sprint. They are also self-managing, meaning they internally decide who does what, when, and
+how.
+
+The Scrum Team is small enough to remain nimble and large enough to complete significant work within
+a Sprint, typically 10 or fewer people. In general, we have found that smaller teams communicate better
+and are more productive. If Scrum Teams become too large, they should consider reorganizing into
+multiple cohesive Scrum Teams, each focused on the same product. Therefore, they should share the
+same Product Goal, Product Backlog, and Product Owner.
+
+The Scrum Team is responsible for all product-related activities from stakeholder collaboration,
+verification, maintenance, operation, experimentation, research and development, and anything else
+that might be required. They are structured and empowered by the organization to manage their own
+work. Working in Sprints at a sustainable pace improves the Scrum Team’s focus and consistency.
+
+The entire Scrum Team is accountable for creating a valuable, useful Increment every Sprint. Scrum
+defines three specific accountabilities within the Scrum Team: the Developers, the Product Owner, and
+the Scrum Master.
+
+Developers
+
+Developers are the people in the Scrum Team that are committed to creating any aspect of a usable
+Increment each Sprint.
+
+The specific skills needed by the Developers are often broad and will vary with the domain of work.
+However, the Developers are always accountable for:
+
+●  Creating a plan for the Sprint, the Sprint Backlog;
+●
+Instilling quality by adhering to a Definition of Done;
+●  Adapting their plan each day toward the Sprint Goal; and,
+●  Holding each other accountable as professionals.
+
+Product Owner
+
+The Product Owner is accountable for maximizing the value of the product resulting from the work of
+the Scrum Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.
+
+5
+
+
+
+
+
+
+
+
+The Product Owner is also accountable for effective Product Backlog management, which includes:
+
+●  Developing and explicitly communicating the Product Goal;
+●  Creating and clearly communicating Product Backlog items;
+●  Ordering Product Backlog items; and,
+●  Ensuring that the Product Backlog is transparent, visible and understood.
+
+The Product Owner may do the above work or may delegate the responsibility to others. Regardless, the
+Product Owner remains accountable.
+
+For Product Owners to succeed, the entire organization must respect their decisions. These decisions
+are visible in the content and ordering of the Product Backlog, and through the inspectable Increment at
+the Sprint Review.
+
+The Product Owner is one person, not a committee. The Product Owner may represent the needs of
+many stakeholders in the Product Backlog. Those wanting to change the Product Backlog can do so by
+trying to convince the Product Owner.
+
+Scrum Master
+
+The Scrum Master is accountable for establishing Scrum as defined in the Scrum Guide. They do this by
+helping everyone understand Scrum theory and practice, both within the Scrum Team and the
+organization.
+
+The Scrum Master is accountable for the Scrum Team’s effectiveness. They do this by enabling the
+Scrum Team to improve its practices, within the Scrum framework.
+
+Scrum Masters are true leaders who serve the Scrum Team and the larger organization.
+
+The Scrum Master serves the Scrum Team in several ways, including:
+
+●  Coaching the team members in self-management and cross-functionality;
+●  Helping the Scrum Team focus on creating high-value Increments that meet the Definition of
+
+Done;
+
+●  Causing the removal of impediments to the Scrum Team’s progress; and,
+●  Ensuring that all Scrum events take place and are positive, productive, and kept within the
+
+timebox.
+
+The Scrum Master serves the Product Owner in several ways, including:
+
+6
+
+
+
+
+
+
+
+
+
+
+
+
+
+●  Helping find techniques for effective Product Goal definition and Product Backlog management;
+●  Helping the Scrum Team understand the need for clear and concise Product Backlog items;
+●  Helping establish empirical product planning for a complex environment; and,
+●  Facilitating stakeholder collaboration as requested or needed.
+
+The Scrum Master serves the organization in several ways, including:
+
+●  Leading, training, and coaching the organization in its Scrum adoption;
+●  Planning and advising Scrum implementations within the organization;
+●  Helping employees and stakeholders understand and enact an empirical approach for complex
+
+work; and,
+
+●  Removing barriers between stakeholders and Scrum Teams.
+
+Scrum Events
+The Sprint is a container for all other events. Each event in Scrum is a formal opportunity to inspect and
+adapt Scrum artifacts. These events are specifically designed to enable the transparency required.
+Failure to operate any events as prescribed results in lost opportunities to inspect and adapt. Events are
+used in Scrum to create regularity and to minimize the need for meetings not defined in Scrum.
+Optimally, all events are held at the same time and place to reduce complexity.
+
+The Sprint
+
+Sprints are the heartbeat of Scrum, where ideas are turned into value.
+
+They are fixed length events of one month or less to create consistency. A new Sprint starts immediately
+after the conclusion of the previous Sprint.
+
+All the work necessary to achieve the Product Goal, including Sprint Planning, Daily Scrums, Sprint
+Review, and Sprint Retrospective, happen within Sprints.
+
+During the Sprint:
+
+●  No changes are made that would endanger the Sprint Goal;
+●  Quality does not decrease;
+●  The Product Backlog is refined as needed; and,
+●  Scope may be clarified and renegotiated with the Product Owner as more is learned.
+
+Sprints enable predictability by ensuring inspection and adaptation of progress toward a Product Goal at
+least every calendar month. When a Sprint’s horizon is too long the Sprint Goal may become invalid,
+complexity may rise, and risk may increase. Shorter Sprints can be employed to generate more learning
+
+7
+
+
+
+
+
+
+
+
+
+cycles and limit risk of cost and effort to a smaller time frame. Each Sprint may be considered a short
+project.
+
+Various practices exist to forecast progress, like burn-downs, burn-ups, or cumulative flows. While
+proven useful, these do not replace the importance of empiricism. In complex environments, what will
+happen is unknown. Only what has already happened may be used for forward-looking decision making.
+
+A Sprint could be cancelled if the Sprint Goal becomes obsolete. Only the Product Owner has the
+authority to cancel the Sprint.
+
+Sprint Planning
+
+Sprint Planning initiates the Sprint by laying out the work to be performed for the Sprint. This resulting
+plan is created by the collaborative work of the entire Scrum Team.
+
+The Product Owner ensures that attendees are prepared to discuss the most important Product Backlog
+items and how they map to the Product Goal. The Scrum Team may also invite other people to attend
+Sprint Planning to provide advice.
+
+Sprint Planning addresses the following topics:
+
+Topic One: Why is this Sprint valuable?
+
+The Product Owner proposes how the product could increase its value and utility in the current Sprint.
+The whole Scrum Team then collaborates to define a Sprint Goal that communicates why the Sprint is
+valuable to stakeholders. The Sprint Goal must be finalized prior to the end of Sprint Planning.
+
+Topic Two: What can be Done this Sprint?
+
+Through discussion with the Product Owner, the Developers select items from the Product Backlog to
+include in the current Sprint. The Scrum Team may refine these items during this process, which
+increases understanding and confidence.
+
+Selecting how much can be completed within a Sprint may be challenging. However, the more the
+Developers know about their past performance, their upcoming capacity, and their Definition of Done,
+the more confident they will be in their Sprint forecasts.
+
+Topic Three: How will the chosen work get done?
+
+For each selected Product Backlog item, the Developers plan the work necessary to create an Increment
+that meets the Definition of Done. This is often done by decomposing Product Backlog items into
+smaller work items of one day or less. How this is done is at the sole discretion of the Developers. No
+one else tells them how to turn Product Backlog items into Increments of value.
+
+8
+
+
+
+
+
+
+
+
+
+
+The Sprint Goal, the Product Backlog items selected for the Sprint, plus the plan for delivering them are
+together referred to as the Sprint Backlog.
+
+Sprint Planning is timeboxed to a maximum of eight hours for a one-month Sprint. For shorter Sprints,
+the event is usually shorter.
+
+Daily Scrum
+
+The purpose of the Daily Scrum is to inspect progress toward the Sprint Goal and adapt the Sprint
+Backlog as necessary, adjusting the upcoming planned work.
+
+The Daily Scrum is a 15-minute event for the Developers of the Scrum Team. To reduce complexity, it is
+held at the same time and place every working day of the Sprint. If the Product Owner or Scrum Master
+are actively working on items in the Sprint Backlog, they participate as Developers.
+
+The Developers can select whatever structure and techniques they want, as long as their Daily Scrum
+focuses on progress toward the Sprint Goal and produces an actionable plan for the next day of work.
+This creates focus and improves self-management.
+
+Daily Scrums improve communications, identify impediments, promote quick decision-making, and
+consequently eliminate the need for other meetings.
+
+The Daily Scrum is not the only time Developers are allowed to adjust their plan. They often meet
+throughout the day for more detailed discussions about adapting or re-planning the rest of the Sprint’s
+work.
+
+Sprint Review
+
+The purpose of the Sprint Review is to inspect the outcome of the Sprint and determine future
+adaptations. The Scrum Team presents the results of their work to key stakeholders and progress
+toward the Product Goal is discussed.
+
+During the event, the Scrum Team and stakeholders review what was accomplished in the Sprint and
+what has changed in their environment. Based on this information, attendees collaborate on what to do
+next. The Product Backlog may also be adjusted to meet new opportunities. The Sprint Review is a
+working session and the Scrum Team should avoid limiting it to a presentation.
+
+The Sprint Review is the second to last event of the Sprint and is timeboxed to a maximum of four hours
+for a one-month Sprint. For shorter Sprints, the event is usually shorter.
+
+9
+
+
+
+
+
+
+
+
+
+
+Sprint Retrospective
+
+The purpose of the Sprint Retrospective is to plan ways to increase quality and effectiveness.
+
+The Scrum Team inspects how the last Sprint went with regards to individuals, interactions, processes,
+tools, and their Definition of Done. Inspected elements often vary with the domain of work.
+Assumptions that led them astray are identified and their origins explored. The Scrum Team discusses
+what went well during the Sprint, what problems it encountered, and how those problems were (or
+were not) solved.
+
+The Scrum Team identifies the most helpful changes to improve its effectiveness. The most impactful
+improvements are addressed as soon as possible. They may even be added to the Sprint Backlog for the
+next Sprint.
+
+The Sprint Retrospective concludes the Sprint. It is timeboxed to a maximum of three hours for a one-
+month Sprint. For shorter Sprints, the event is usually shorter.
+
+Scrum Artifacts
+Scrum’s artifacts represent work or value. They are designed to maximize transparency of key
+information. Thus, everyone inspecting them has the same basis for adaptation.
+
+Each artifact contains a commitment to ensure it provides information that enhances transparency and
+focus against which progress can be measured:
+
+●  For the Product Backlog it is the Product Goal.
+●  For the Sprint Backlog it is the Sprint Goal.
+●  For the Increment it is the Definition of Done.
+
+These commitments exist to reinforce empiricism and the Scrum values for the Scrum Team and their
+stakeholders.
+
+Product Backlog
+
+The Product Backlog is an emergent, ordered list of what is needed to improve the product.  It is the
+single source of work undertaken by the Scrum Team.
+
+Product Backlog items that can be Done by the Scrum Team within one Sprint are deemed ready for
+selection in a Sprint Planning event. They usually acquire this degree of transparency after refining
+activities. Product Backlog refinement is the act of breaking down and further defining Product Backlog
+items into smaller more precise items. This is an ongoing activity to add details, such as a description,
+order, and size. Attributes often vary with the domain of work.
+
+10
+
+
+
+
+
+
+
+
+
+The Developers who will be doing the work are responsible for the sizing. The Product Owner may
+influence the Developers by helping them understand and select trade-offs.
+
+Commitment: Product Goal
+
+The Product Goal describes a future state of the product which can serve as a target for the Scrum Team
+to plan against. The Product Goal is in the Product Backlog. The rest of the Product Backlog emerges to
+define “what” will fulfill the Product Goal.
+
+A product is a vehicle to deliver value. It has a clear boundary, known stakeholders, well-defined
+users or customers. A product could be a service, a physical product, or something more abstract.
+
+The Product Goal is the long-term objective for the Scrum Team. They must fulfill (or abandon) one
+objective before taking on the next.
+
+Sprint Backlog
+
+The Sprint Backlog is composed of the Sprint Goal (why), the set of Product Backlog items selected for
+the Sprint (what), as well as an actionable plan for delivering the Increment (how).
+
+The Sprint Backlog is a plan by and for the Developers. It is a highly visible, real-time picture of the work
+that the Developers plan to accomplish during the Sprint in order to achieve the Sprint Goal.
+Consequently, the Sprint Backlog is updated throughout the Sprint as more is learned. It should have
+enough detail that they can inspect their progress in the Daily Scrum.
+
+Commitment: Sprint Goal
+
+The Sprint Goal is the single objective for the Sprint. Although the Sprint Goal is a commitment by the
+Developers, it provides flexibility in terms of the exact work needed to achieve it. The Sprint Goal also
+creates coherence and focus, encouraging the Scrum Team to work together rather than on separate
+initiatives.
+
+The Sprint Goal is created during the Sprint Planning event and then added to the Sprint Backlog.  As the
+Developers work during the Sprint, they keep the Sprint Goal in mind. If the work turns out to be
+different than they expected, they collaborate with the Product Owner to negotiate the scope of the
+Sprint Backlog within the Sprint without affecting the Sprint Goal.
+
+Increment
+
+An Increment is a concrete stepping stone toward the Product Goal. Each Increment is additive to all
+prior Increments and thoroughly verified, ensuring that all Increments work together. In order to
+provide value, the Increment must be usable.
+
+11
+
+
+
+
+
+
+
+Multiple Increments may be created within a Sprint. The sum of the Increments is presented at the
+Sprint Review thus supporting empiricism. However, an Increment may be delivered to stakeholders
+prior to the end of the Sprint. The Sprint Review should never be considered a gate to releasing value.
+
+Work cannot be considered part of an Increment unless it meets the Definition of Done.
+
+Commitment: Definition of Done
+
+The Definition of Done is a formal description of the state of the Increment when it meets the quality
+measures required for the product.
+
+The moment a Product Backlog item meets the Definition of Done, an Increment is born.
+
+The Definition of Done creates transparency by providing everyone a shared understanding of what
+work was completed as part of the Increment. If a Product Backlog item does not meet the Definition of
+Done, it cannot be released or even presented at the Sprint Review. Instead, it returns to the Product
+Backlog for future consideration.
+
+If the Definition of Done for an increment is part of the standards of the organization, all Scrum Teams
+must follow it as a minimum. If it is not an organizational standard, the Scrum Team must create a
+Definition of Done appropriate for the product.
+
+The Developers are required to conform to the Definition of Done. If there are multiple Scrum Teams
+working together on a product, they must mutually define and comply with the same Definition of Done.
+
+12
+
+
+
+
+
+
+
+
+
+
+End Note
+Scrum is free and offered in this Guide. The Scrum framework, as outlined herein, is immutable. While
+implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists only in its entirety
+and functions well as a container for other techniques, methodologies, and practices.
+
+Acknowledgements
+
+People
+
+Of the thousands of people who have contributed to Scrum, we should single out those who were
+instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John Scumniotales, and Ken
+Schwaber worked with Mike Smith and Chris Martin, and all of them worked together. Many others
+contributed in the ensuing years and without their help Scrum would not be refined as it is today.
+
+Scrum Guide History
+
+Ken Schwaber and Jeff Sutherland first co-presented Scrum at the OOPSLA Conference in 1995. It
+essentially documented the learning that Ken and Jeff gained over the previous few years and made
+public the first formal definition of Scrum.
+
+The Scrum Guide documents Scrum as developed, evolved, and sustained for 30-plus years by Jeff
+Sutherland and Ken Schwaber. Other sources provide patterns, processes, and insights that complement
+the Scrum framework. These may increase productivity, value, creativity, and satisfaction with the
+results.
+
+The complete history of Scrum is described elsewhere. To honor the first places where it was tried and
+proven, we recognize Individual Inc., Newspage, Fidelity Investments, and IDX (now GE Medical).
+
+© 2020 Ken Schwaber and Jeff Sutherland
+
+This publication is offered for license under the Attribution Share-Alike license of Creative Commons,
+accessible at https://creativecommons.org/licenses/by-sa/4.0/legalcode and also described in summary
+form at https://creativecommons.org/licenses/by-sa/4.0/. By utilizing this Scrum Guide, you
+acknowledge and agree that you have read and agree to be bound by the terms of the Attribution
+Share-Alike license of Creative Commons.
+
+13
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/specifications/V-Modell-XT/v-modell-xt.md
+++ b/specifications/V-Modell-XT/v-modell-xt.md
@@ -1,0 +1,111 @@
+[![](//upload.wikimedia.org/wikipedia/commons/thumb/3/3a/V-Modell.svg/500px-V-Modell.svg.png)](/wiki/Datei:V-Modell.svg)Phasen des V-Modells über Zeit und Detaillierung
+
+Das **V-Modell** ist ein [Vorgehensmodell](/wiki/Vorgehensmodell_\(Software\) "Vorgehensmodell \(Software\)") bzw. Prozessreferenzmodell[1], welches ursprünglich für die Softwareentwicklung konzipiert wurde. Ähnlich dem [Wasserfallmodell](/wiki/Wasserfallmodell "Wasserfallmodell") organisiert es den [Softwareentwicklungsprozess](/wiki/Softwaretechnik "Softwaretechnik") in Phasen. Zusätzlich zu diesen Entwicklungsphasen definiert das V-Modell auch das Vorgehen zur Qualitätssicherung ([Testen](/wiki/Softwaretest "Softwaretest")), indem den einzelnen Entwicklungsphasen Testphasen gegenübergestellt werden. Auf der linken Seite wird mit einer funktionalen/fachlichen Spezifikation begonnen, die immer tiefer detailliert zu einer technischen Spezifikation und Implementierungsgrundlage ausgebaut wird. In der Spitze erfolgt die [Implementierung](/wiki/Implementierung "Implementierung"), die anschließend auf der rechten Seite gegen die entsprechenden Spezifikationen der linken Seite getestet wird. So entsteht bildlich das namensgebende „V“, welches die einzelnen Entwicklungsebenen ihren jeweiligen Testebenen gegenüberstellt.
+
+Zum V-Modell im Allgemeinen werden in der Literatur die Anzahl der Phasen und auch deren Bezeichnungen unterschiedlich dargestellt, jedoch immer mit 1:1-Gegenüberstellung von Entwurfs- und Teststufen.
+
+Die Prozesse des V-Modells werden mit einem Prozessbewertungsmodell, z. B. nach ISO 33000-Familie bewertet. Eine Umsetzung der Norm ist die [Automotive SPICE](/wiki/Automotive_SPICE "Automotive SPICE").
+
+Das V-Modell ist nicht zu verwechseln mit dem [Verfügbarkeitsmodell](/w/index.php?title=Verf%C3%BCgbarkeitsmodell_\(Transportsysteme\)&action=edit&redlink=1 "Verfügbarkeitsmodell \(Transportsysteme\) \(Seite nicht vorhanden\)") (auch abgekürzt als "V-Modell").[2][3]
+
+## Geschichte
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=1 "Abschnitt bearbeiten: Geschichte") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=1 "Quellcode des Abschnitts bearbeiten: Geschichte")]
+
+Vorgeschlagen wurde dieses Vorgehen zuerst von dem US-amerikanischen Softwareingenieur [Barry Boehm](/wiki/Barry_Boehm "Barry Boehm") im Jahre 1979 und basiert auf dem [Wasserfallmodell](/wiki/Wasserfallmodell "Wasserfallmodell"): Die Phasenergebnisse sind bindende Vorgaben für die nächsttiefere [Projektphase](/wiki/Projektphase "Projektphase"). Der linke, nach unten führende Ast für die Spezifizierungsphasen schließt mit der Realisierungsphase ab. Eine Erweiterung gegenüber dem Wasserfallmodell sind die zeitlich nachfolgenden Testphasen, die im rechten, nach oben führenden Ast dargestellt werden. Den spezifizierenden Phasen stehen jeweils testende Phasen gegenüber, was in der Darstellung ein charakteristisches „V“ ergibt, das dem Modell auch den Namen gab.[4] Diese Gegenüberstellung soll zu einer möglichst hohen [Testabdeckung](/wiki/Testabdeckung "Testabdeckung") führen, weil die [Spezifikationen](/wiki/Spezifikation "Spezifikation") der jeweiligen Entwicklungsstufen die Grundlage für die Tests ([Testfälle](/wiki/Testfall "Testfall")) in den entsprechenden [Teststufen](/wiki/Softwaretest#Teststufen "Softwaretest") sind.
+
+## Anwendungen
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=2 "Abschnitt bearbeiten: Anwendungen") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=2 "Quellcode des Abschnitts bearbeiten: Anwendungen")]
+
+### IT-Entwicklungsprojekte
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=3 "Abschnitt bearbeiten: IT-Entwicklungsprojekte") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=3 "Quellcode des Abschnitts bearbeiten: IT-Entwicklungsprojekte")]
+
+Das allgemeine V-Modell ist die Grundlage von Entwicklungsstandards wie z. B. dem [V-Modell (Entwicklungsstandard)](/wiki/V-Modell_\(Entwicklungsstandard\) "V-Modell \(Entwicklungsstandard\)") der öffentlichen Hand in Deutschland.
+
+### Das V-Modell in der Entwicklung mechatronischer Systeme
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=4 "Abschnitt bearbeiten: Das V-Modell in der Entwicklung mechatronischer Systeme") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=4 "Quellcode des Abschnitts bearbeiten: Das V-Modell in der Entwicklung mechatronischer Systeme")]
+
+[![](//upload.wikimedia.org/wikipedia/commons/thumb/f/f0/V-Modell_VDI-VDE-2206_Nov2021.png/250px-V-Modell_VDI-VDE-2206_Nov2021.png)](/wiki/Datei:V-Modell_VDI-VDE-2206_Nov2021.png)V-Modell nach VDI/VDE 2206 aus dem Jahr 2021
+
+Spätestens seit 2004 wird das V-Modell auch allgemeiner in Entwicklungsprozessen verwendet. So empfiehlt die Richtlinie VDI/VDE 2206 das V-Modell als Teil der „Entwicklungsmethodik für [mechatronische](/wiki/Mechatronik "Mechatronik") Systeme“. Hintergrund ist dabei die zunehmende Integration von [mechanischen](/wiki/Mechanik "Mechanik"), [elektrischen](/wiki/Elektrizit%C3%A4t "Elektrizität") und [informationstechnischen](/wiki/Software "Software") Komponenten in mechatronischen Systemen und die damit verbundene Steigerung der Komplexität[5].
+
+Ausgangspunkt ist dabei meist eine konkrete Anforderung bzw. eine Anforderungsliste in Form eines Entwicklungsauftrags. Diese Anforderungen stellen zugleich den Maßstab dar, nach dem das spätere Produkt zu bewerten ist. Im Systementwurf wird die Gesamtfunktion des Systems bzw. des späteren Produktes in Teilfunktionen zerlegt. Sind die Teilfunktionen ermittelt erfolgt die Konkretisierung des Lösungskonzeptes meist getrennt in den einzelnen Fachdisziplinen (Domänen). Die konkreten Lösungen der einzelnen Disziplinen werden im Rahmen der Systemintegration zu einem Gesamtsystem verbunden und ihr Zusammenwirken untersucht. Fortlaufend wird dabei im Zuge der Eigenschaftsabsicherung der jetzige Entwurf gegen die spezifizierten Anforderungen geprüft, dadurch wird sichergestellt, dass die gewünschten Eigenschaften mit den tatsächlichen Eigenschaften übereinstimmen. Der gesamte Prozess kann dabei durch rechnergestützte Modellierung und Simulation unterstützt werden. Ergebnis eines durchlaufenen Zyklus des V-Modells ist das „Produkt“, wobei es sich hierbei um einen bestimmten Reifegrad (Funktionsmuster, [Prototyp](/wiki/Prototyp_\(Technik\) "Prototyp \(Technik\)"), Vorserienmuster etc.) des geplanten Endproduktes handeln kann. Das V-Modell stellt also einen iterativen Prozess dar, der sich schrittweise der endgültigen Lösung annähert und je nach Komplexität des Endproduktes vielfach durchlaufen wird.[6]
+
+### Das V-Modell als Datenstruktur
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=5 "Abschnitt bearbeiten: Das V-Modell als Datenstruktur") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=5 "Quellcode des Abschnitts bearbeiten: Das V-Modell als Datenstruktur")]
+
+Neben der Funktion als Prozessmodell kann das V-Modell auch die Grundlage für die [Datenstruktur](/wiki/Datenstruktur "Datenstruktur") in der Entwicklung übernehmen. Dabei werden die verschiedenen Artefakte der Entwicklung auf dem V positioniert: Links oben die Anforderungen, bis zur Mitte unten zur Implementierung und auf dem rechten Arm die dazugehörigen [Verifizierungs- und Validierungs](/wiki/Verifizierung_und_Validierung "Verifizierung und Validierung")-Artefakte. Eine [Rückverfolgbarkeit (engl. "Traceability")](/wiki/R%C3%BCckverfolgbarkeit_\(Anforderungsmanagement\) "Rückverfolgbarkeit \(Anforderungsmanagement\)") zwischen den Artefakten unterstützt das Arbeiten mit den Artefakten. Diese Umsetzung ist in den gängigen [Anforderungsmanagementwerkzeugen](/wiki/Anforderungsmanagement-Software "Anforderungsmanagement-Software") üblich[7].
+
+## Weiterentwicklung
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=6 "Abschnitt bearbeiten: Weiterentwicklung") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=6 "Quellcode des Abschnitts bearbeiten: Weiterentwicklung")]
+
+Auf Basis von Erfahrungen aus der industriellen Anwendung und dem technologischen Fortschritt wurde seither eine Vielzahl von Weiterentwicklungen des V-Modells publiziert[8]. Durch Hinwendung zu [agilen Methoden](/wiki/Agile_Methoden "Agile Methoden"), [Concurrent-Engineering](/wiki/Simultaneous_Engineering "Simultaneous Engineering")-Prozessen und die zeitgleiche Relevanz des [Systems Engineerings](/wiki/Systems_Engineering "Systems Engineering") wurde das V-Modell um 2000 beispielsweise zum _W-Modell_ weiterentwickelt.[9] Mit einer vorgezogenen Testphase und der Einbindung von [Simulationsprozessen](/wiki/Simulationsbasierte_Optimierung "Simulationsbasierte Optimierung") und statistischen Methoden zur Fehlervermeidung greift das W-Modell Maßnahmen auf, die zur Parallelisierung von Arbeitsschritten genutzt werden können.[10] Es dient damit als Möglichkeit, agile Ansätze in klassische Arbeitsumfelder einzubetten.[11] Der Begriff findet vorrangig im deutschsprachigen Raum Verwendung.
+
+Die Richtlinie VDI 2206 wurde im VDI in den Jahren 2014 bis 2021 von dem Fachausschuss 4.10 „Interdisziplinäre Produktentstehung“ der VDI/VDE-Gesellschaft Mess- und Automatisierungstechnik überarbeitet und im November 2021 veröffentlicht. Hierbei wurden auf Basis einer Schwachstellenanalyse[12] der hohen Interdisziplinarität, Komplexität und Heterogenität moderner Systeme[13] Rechnung getragen und das V-Modell erneuert. Die Entwicklungen moderner Produkte, die neben einem mechanischen, häufig elektronischen sowie möglichen Software-Anteile mit einer Verbindung zum [Internet der Dinge](/wiki/Internet_der_Dinge "Internet der Dinge") und Dienste umfassen kann, angepasst. Es existieren neben der neuen Richtlinie VDI/VDE 2206 „Entwicklung mechatronischer und cyber-physischer Systeme“ weitere wissenschaftliche Veröffentlichungen[5]. Zentral war die Erneuerung des Bildes des V-Modells, das zum Download zur Verfügung steht, siehe bei den **Weblinks**.
+
+## Weblinks
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=7 "Abschnitt bearbeiten: Weblinks") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=7 "Quellcode des Abschnitts bearbeiten: Weblinks")]
+
+![](//upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/20px-Commons-logo.svg.png)
+
+**[Commons : V-Modell](https://commons.wikimedia.org/wiki/Category:V-models?uselang=de)** – Sammlung von Bildern, Videos und Audiodateien
+
+  * [_Richtlinie VDI/VDE 2206 "Entwicklung mechatronischer und cyber-physischer Systeme"._](https://www.vdi.de/richtlinien/programme-zu-vdi-richtlinien/vdi-2206) In: _VDI._ Abgerufen am 16. November 2022.
+  * V-Modell VDI/VDE 2206 Deutsch ([PDF](https://www.vdi.de/fileadmin/pages/vdi_de/redakteure/richtlinien/dateien/VDI_2206_V-Modell_de.pdf))
+  * V-model VDI/VDE 2206 English ([PDF](https://www.vdi.de/fileadmin/pages/vdi_de/redakteure/richtlinien/dateien/VDI_2206_V-model_en.pdf))
+
+## Siehe auch
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=8 "Abschnitt bearbeiten: Siehe auch") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=8 "Quellcode des Abschnitts bearbeiten: Siehe auch")]
+
+  * [Liste von Softwareentwicklungsprozessen](/wiki/Liste_von_Softwareentwicklungsprozessen "Liste von Softwareentwicklungsprozessen")
+  * [V-Modell (Entwicklungsstandard)](/wiki/V-Modell_\(Entwicklungsstandard\) "V-Modell \(Entwicklungsstandard\)")
+
+## Literatur
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=9 "Abschnitt bearbeiten: Literatur") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=9 "Quellcode des Abschnitts bearbeiten: Literatur")]
+
+### Fachbücher
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=10 "Abschnitt bearbeiten: Fachbücher") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=10 "Quellcode des Abschnitts bearbeiten: Fachbücher")]
+
+  * Paul Alpar, Rainer Alt, Frank Bensberg, Peter Weimann: Anwendungsorientierte Wirtschaftsinformatik: Strategische Planung, Entwicklung und Nutzung von Informationssystemen. Springer Fachmedien Wiesbaden, Wiesbaden 2019, [ISBN 978-3-658-25580-0](/wiki/Spezial:ISBN-Suche/9783658255800), S. 347 ff., [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.1007/978-3-658-25581-7](https://doi.org/10.1007/978-3-658-25581-7).
+  * Kai Borgeest: Elektronik in der Fahrzeugtechnik: Hardware, Software, Systeme und Projektmanagement. Springer Fachmedien Wiesbaden, Wiesbaden 2021, [ISBN 978-3-658-23663-2](/wiki/Spezial:ISBN-Suche/9783658236632), [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.1007/978-3-658-23664-9](https://doi.org/10.1007/978-3-658-23664-9).
+  * Jan Friedrich, Marco Kuhrmann, Marc Sihling, Ulrike Hammerschall: Das V-Modell XT (= Informatik im Fokus). Springer Berlin Heidelberg, Berlin, Heidelberg 2008, [ISBN 978-3-540-76403-8](/wiki/Spezial:ISBN-Suche/9783540764038), [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.1007/978-3-540-76404-5](https://doi.org/10.1007/978-3-540-76404-5).
+  * Thomas Grechenig, Mario Bernhart, Roland Breiteneder, Karin Kappel: _Softwaretechnik._ Pearson Studium, München u. a. 2010, [ISBN 978-3-86894-007-7](/wiki/Spezial:ISBN-Suche/9783868940077), [S. 375](https://books.google.de/books?id=RcSvlD2-QQ0C&pg=PA375&hl=de).
+  * Ernest Wallmüller: _Software-Qualitätsmanagement in der Praxis._ 2\. völlig überarbeitete Auflage. Hanser Verlag, München u. a. 2001, [ISBN 3-446-21367-8](/wiki/Spezial:ISBN-Suche/3446213678), [S. 131](https://books.google.de/books?id=BdWJuc7i0QEC&pg=PA131&hl=de).
+  * Fabian Wolf: Fahrzeuginformatik: Eine Einführung in die Software- und Elektronikentwicklung aus der Praxis der Automobilindustrie. Springer Fachmedien Wiesbaden, Wiesbaden 2018, [ISBN 978-3-658-21223-0](/wiki/Spezial:ISBN-Suche/9783658212230), [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.1007/978-3-658-21224-7](https://doi.org/10.1007/978-3-658-21224-7).
+
+### Historische Werke und Klassiker
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=11 "Abschnitt bearbeiten: Historische Werke und Klassiker") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=11 "Quellcode des Abschnitts bearbeiten: Historische Werke und Klassiker")]
+
+  * Tom DeMarco, Timothy R. Lister (Hrsg.): Software state-of-the-art: selected papers. Dorset House Pub, New York, N.Y 1990, [ISBN 978-0-932633-14-9](/wiki/Spezial:ISBN-Suche/9780932633149) ([archive.org](https://archive.org/details/softwarestateoft0000unse)).
+
+## Einzelnachweise
+
+[[Bearbeiten](/w/index.php?title=V-Modell&veaction=edit&section=12 "Abschnitt bearbeiten: Einzelnachweise") | [Quelltext bearbeiten](/w/index.php?title=V-Modell&action=edit&section=12 "Quellcode des Abschnitts bearbeiten: Einzelnachweise")]
+
+  1. ↑ G. Müller-Ettrich: System Development with V-Model and UML. In: The Unified Modeling Language. Physica-Verlag HD, Heidelberg 1998, [ISBN 978-3-7908-1105-6](/wiki/Spezial:ISBN-Suche/9783790811056), S. 238–249, [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.1007/978-3-642-48673-9_16](https://doi.org/10.1007/978-3-642-48673-9_16) (englisch, [springer.com](https://link.springer.com/chapter/10.1007/978-3-642-48673-9_16) [abgerufen am 29. November 2023]).
+  2. ↑ [_BMDV - Das V-Modell (Verfügbarkeitsmodell)._](https://www.bmdv.bund.de/SharedDocs/DE/Artikel/StB/oepp-geschaeftsmodelle-v-modell.html) [Bundesministerium für Digitales und Verkehr](/wiki/Bundesministerium_f%C3%BCr_Digitales_und_Verkehr "Bundesministerium für Digitales und Verkehr"), 2023, abgerufen am 29. November 2023.
+  3. ↑ Johannes Fottner, Stefan Galka, Sebastian Habenicht, Eva Klenk, Ingolf Meinhardt, Thorsten Schmidt: Allgemeine Grundlagen für die Planung von Transportsystemen. In: Planung von innerbetrieblichen Transportsystemen. Springer Berlin Heidelberg, Berlin, Heidelberg 2022, [ISBN 978-3-662-63972-6](/wiki/Spezial:ISBN-Suche/9783662639726), S. 77–120, [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.1007/978-3-662-63973-3_4](https://doi.org/10.1007/978-3-662-63973-3_4) ([springer.com](https://link.springer.com/10.1007/978-3-662-63973-3_4) [abgerufen am 29. November 2023]).
+  4. ↑ [_Fragen und Antworten._](https://www.cio.bund.de/SharedDocs/faq-liste/Webs/CIO/DE/digitaler_wandel_fragen_antworten.html?nn=18094882) Bundesministerium des Innern und für Heimat, 2023, abgerufen am 29. November 2023.
+  5. ↑ a b Iris Graessler, Julian Hentze: The new V-Model of VDI 2206 and its validation. In: at - Automatisierungstechnik. Band 68, Nr. 5, 1. Mai 2020, [ISSN](/wiki/Internationale_Standardnummer_f%C3%BCr_fortlaufende_Sammelwerke "Internationale Standardnummer für fortlaufende Sammelwerke") [2196-677X](https://zdb-katalog.de/list.xhtml?t=iss%3D%222196-677X%22&key=cql), S. 312–324, [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.1515/auto-2020-0015](https://doi.org/10.1515/auto-2020-0015) ([degruyter.com](https://www.degruyter.com/document/doi/10.1515/auto-2020-0015/html) [abgerufen am 5. Januar 2022]).
+  6. ↑ Verein Deutscher Ingenieure (Hrsg.): VDI 2206 - Entwicklungsmethodik für mechatronische Systeme. Beuth Verlag GmbH.
+  7. ↑ SE-Trends: [Was ist eigentlich das V-Modell?](https://www.se-trends.de/was-ist-eigentlich-das-v-modell/)
+  8. ↑ Iris Graessler, Julian Hentze, Tobias Bruckmann: V-MODELS FOR INTERDISCIPLINARY SYSTEMS ENGINEERING. In: DS 92: Proceedings of the DESIGN 2018 15th International Design Conference. 2018, S. 747–756, [doi](/wiki/Digital_Object_Identifier "Digital Object Identifier"):[10.21278/idc.2018.0333](https://doi.org/10.21278/idc.2018.0333) ([designsociety.org](https://www.designsociety.org/publication/40489/V-MODELS+FOR+INTERDISCIPLINARY+SYSTEMS+ENGINEERING) [abgerufen am 5. Januar 2022]).
+  9. ↑ A. Spillner: [_From V-model to W-model. Establishing the Whole Test Process._](https://www.tib.eu/de/suchen/id/BLCP:CN039119328/From-V-model-to-W-model-Establishing-the-Whole/) In: _Leibniz-Informationszentrum Technik und Naturwissenschaften Universitätsbibliothek._ Technische Informationsbibliothek (TIB) Hannover, 2000, abgerufen am 18. Juni 2019 (englisch).
+  10. ↑ Reiner Anderl, Roland Nattermann, Thomas Rollmann: [_Das W-Modell. Systems Engineering in der Entwicklung aktiver Systeme._](https://d-nb.info/1019526661/34) In: _Katalog der Deutschen Nationalbibliothek._ Technische Universität Darmstadt. Fachgebiet Datenverarbeitung in der Konstruktion, abgerufen am 18. Juni 2019.
+  11. ↑ A. Spillner: [_Das W-Modell. Vorteile der agilen Prozesse in einem konservativen Umfeld nutzen._](https://www.gi-hb-ol.de/uta/gi-rg/WModellSpillner.pdf) In: _Gesellschaft für Informatik. Regionalgruppe Bremen Oldenburg._ Hochschule Bremen, 13. Mai 2003, abgerufen am 18. Juni 2019.
+  12. ↑ Gräßler I, Hentze J, Yang X. Eleven Potentials for mechatronic V-model. In: _Production Engineering and Management, 6th International Conference, Band 01/2016_. Vol 01/2016. Lemgo: Ostwestfalen-Lippe University of Applied Sciences ; 2016:257-268.
+  13. ↑ Gräßler I. A New V-Model for Interdisciplinary Product Engineering. In: Technische Universität Ilmenau, Marketing Division, ed. _59th IWK. Ilmenau Scientific Colloquium_. Technische Universität Ilmenau; 2017:1-6.
+
+![](https://de.wikipedia.org/wiki/Special:CentralAutoLogin/start?useformat=desktop&type=1x1&usesul3=1)
+
+Abgerufen von „[https://de.wikipedia.org/w/index.php?title=V-Modell&oldid=258803524](https://de.wikipedia.org/w/index.php?title=V-Modell&oldid=258803524)“


### PR DESCRIPTION
Converted the original framework specifications (HTML and PDF) into cleaned Markdown files. This involved installing necessary Python libraries, implementing a cleaning script to strip web-scraped boilerplate, and correcting the source for the Hermes specification which was previously a 'page not found' result. Documentation was updated to track this progress and document the strategy.

Fixes #9

---
*PR created automatically by Jules for task [1518157190085284366](https://jules.google.com/task/1518157190085284366) started by @chatelao*