### PR TITLE
Implement initial schema for Fusion Framework

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -1,5 +1,14 @@
 # DECISION Log
 
+## 2026-03-17 09:00 - Unified Framework Schema Architecture
+- **Problem**: Define the structure of the JSON Schema to represent the unified framework (roles, deliverables, process).
+- **Solution 1 (Chosen): Single Monolithic Schema**
+  - Reasoning: Simple to validate everything at once and ensures referential integrity easily across roles, deliverables, and process steps.
+- **Solution 2: Split Schemas (Modular)**
+  - Reasoning: Provides better modularity for individual components but increases complexity in managing cross-references and unified validation.
+- **Solution 3: Multi-level Schema with External Definitions**
+  - Reasoning: Offers high reuse through references but is more complex to manage and may hinder "ease of interaction" for human handlers.
+
 ## 2026-03-16 10:00 - Unified Process & Deliverables Architecture
 - **Problem**: Define unified deliverables and process steps for the Fusion framework that balance AI observability with the human "Handler" role model.
 - **Solution 1: Phase-based Model (Classic Lifecycle)**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,6 @@
 # ROADMAP
 
 ## Planned
-- [ ] Implement initial schema in `/src/schema` using YAML and JSON Schema.
 - [ ] Create initial test data in `/src/data` to verify schema and role definitions.
 - [ ] Develop scripts in `/src/scripts` to verify the data and generate deliverables.
 - [ ] Generate documentation and images in `/src/docs` and `/src/images` from the source data.
@@ -10,6 +9,7 @@
 ## Proposed
 
 ## Finished
+- [x] 2026-03-17: Implemented initial schema in `/src/schema` using YAML and JSON Schema.
 - [x] 2026-03-16: Defined unified deliverables and process steps in `design/unified_process_deliverables.md`.
 - [x] 2026-03-15: Defined unified roles and drafted initial design documentation in `/design/unified_roles.md`.
 - [x] 2026-03-15: Researched and selected YAML/JSON Schema for AI observability and human interaction.

--- a/src/data/test_framework.yaml
+++ b/src/data/test_framework.yaml
@@ -1,0 +1,33 @@
+framework_metadata:
+  name: "Fusion Skill & RACI Framework"
+  version: "1.0.0"
+  description: "A unified project management framework."
+
+roles:
+  - id: "handler-start"
+    name: "Handler of the Start"
+    category: "Strategic"
+    accountability: "Initializing the project and defining success."
+    human_interaction: "Strategic decisions."
+    mapping:
+      Scrum: "Product Owner"
+      PRINCE2: "Executive"
+
+  - id: "handler-conflicts"
+    name: "Handler of Conflicts"
+    category: "Governance"
+    accountability: "Resolving priority clashes."
+    human_interaction: "Value-based prioritization."
+
+deliverables:
+  - id: "project-vision"
+    name: "Project Vision & Business Case"
+    description: "Defines strategic goal."
+    accountability: "Handler of the Start"
+
+process_steps:
+  - id: "starting-decision"
+    name: "The Starting Decision"
+    primary_roles: ["Handler of the Start"]
+    objective: "Establish the 'Why' and 'Whether'."
+    decision_point: "Authorization to Invest"

--- a/src/schema/framework.schema.json
+++ b/src/schema/framework.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Fusion Framework Schema",
+  "description": "Schema for the unified Fusion Skill & RACI framework incorporating RUP, V-Modell-XT, Hermes, Scrum, and PRINCE2.",
+  "type": "object",
+  "properties": {
+    "framework_metadata": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "description": { "type": "string" }
+      },
+      "required": ["name", "version"]
+    },
+    "roles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "category": {
+            "type": "string",
+            "enum": ["Strategic", "Governance", "Tactical", "Operational", "Technical"]
+          },
+          "accountability": { "type": "string" },
+          "human_interaction": { "type": "string" },
+          "mapping": {
+            "type": "object",
+            "properties": {
+              "Scrum": { "type": "string" },
+              "PRINCE2": { "type": "string" },
+              "Hermes": { "type": "string" },
+              "RUP": { "type": "string" },
+              "V-Modell-XT": { "type": "string" }
+            }
+          }
+        },
+        "required": ["id", "name", "category", "accountability"]
+      }
+    },
+    "deliverables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "accountability": { "type": "string" },
+          "mapping": { "type": "string" }
+        },
+        "required": ["id", "name", "accountability"]
+      }
+    },
+    "process_steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "primary_roles": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "objective": { "type": "string" },
+          "activities": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "decision_point": { "type": "string" }
+        },
+        "required": ["id", "name", "primary_roles", "objective"]
+      }
+    }
+  },
+  "required": ["framework_metadata", "roles", "deliverables", "process_steps"]
+}

--- a/src/scripts/validate_schema.py
+++ b/src/scripts/validate_schema.py
@@ -1,0 +1,33 @@
+import json
+import yaml
+import jsonschema
+import sys
+import os
+
+def validate(data_path, schema_path):
+    with open(schema_path, 'r') as f:
+        schema = json.load(f)
+
+    with open(data_path, 'r') as f:
+        if data_path.endswith('.yaml') or data_path.endswith('.yml'):
+            data = yaml.safe_load(f)
+        else:
+            data = json.load(f)
+
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+        print(f"Validation successful for {data_path} against {schema_path}")
+        return True
+    except jsonschema.exceptions.ValidationError as e:
+        print(f"Validation failed for {data_path} against {schema_path}")
+        print(f"Error: {e.message}")
+        return False
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python validate_schema.py <data_path> <schema_path>")
+        sys.exit(1)
+
+    success = validate(sys.argv[1], sys.argv[2])
+    if not success:
+        sys.exit(1)


### PR DESCRIPTION
This change implements the first planned step in the ROADMAP.md: "Implement initial schema in /src/schema using YAML and JSON Schema". 

Key changes:
1.  **JSON Schema**: Created `src/schema/framework.schema.json` which provides a structured definition for Roles, Deliverables, and Process Steps. This schema is designed for AI observability and supports the mappings to original frameworks (Scrum, PRINCE2, etc.).
2.  **Validation Tooling**: Added `src/scripts/validate_schema.py`, a Python utility to validate YAML or JSON data against the project's schema.
3.  **Verification Data**: Added `src/data/test_framework.yaml` containing sample data for the "Handler" roles and initial process steps to verify the schema implementation.
4.  **Documentation**: Updated `DECISION.md` with the reasoning behind the monolithic schema architecture and updated `ROADMAP.md` to mark the task as finished.

Fixes #25

---
*PR created automatically by Jules for task [2717849701248556498](https://jules.google.com/task/2717849701248556498) started by @chatelao*